### PR TITLE
feat: add method to send instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ To interact with Snaps, you will need to install [MetaMask Flask](https://metama
 
 You will also need a Tari network running, with an indexer. 
 
+For building the project, Node.js version 18 or superior is required.
 
 ## Getting Started
 
@@ -24,6 +25,7 @@ cd tari-snap
 Then you need to build the WebAssembly library used to build Tari transactions:
 ```shell
 cd tari_wallet_lib
+npm install
 npm run build
 ```
 

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/template-snap-monorepo.git"
   },
   "source": {
-    "shasum": "RPx1N+cYy1db0ond5XAea6GXxmwxeXYQnszMf225zZM=",
+    "shasum": "VK8Y00a5SJXYA6IOoT+NI+BEdIyTfWgg+h7tC/4xjOM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/transactions.ts
+++ b/packages/snap/src/transactions.ts
@@ -1,0 +1,93 @@
+import { Json, JsonRpcRequest } from '@metamask/snaps-types';
+import { heading, panel, text } from '@metamask/snaps-ui';
+import * as tari_wallet_lib from './tari_wallet_lib';
+import { sendIndexerRequest } from './tari_indexer_client';
+import { getRistrettoKeyPair } from './keys';
+import { SendInstructionRequest, SendTransactionRequest } from './types';
+
+async function sendTransactionInternal(wasm: tari_wallet_lib.InitOutput, request: SendTransactionRequest) {
+    const { instructions, input_refs, required_substates, is_dry_run } = request;
+
+    const userConfirmation = await snap.request({
+        method: 'snap_dialog',
+        params: {
+            type: 'confirmation',
+            content: panel([
+                heading('New transaction'),
+                text(`This website requests a transaction from your account, do you want to proceed?.`),
+                text('**Instructions:** ' + JSON.stringify(instructions)),
+            ])
+        },
+    });
+    if (!userConfirmation) {
+        return;
+    }
+
+    const accountIndex = 0;
+    const { secret_key, public_key } = await getRistrettoKeyPair(accountIndex);
+
+    // build and sign transaction using the wasm lib
+    const transaction = tari_wallet_lib.create_transaction(secret_key, instructions, input_refs);
+
+    // send the transaction to the indexer
+    const indexer_url = process.env.TARI_INDEXER_URL;
+    const submit_method = 'submit_transaction';
+    let submit_params = {
+        transaction,
+        is_dry_run,
+        required_substates,
+    };
+
+    await sendIndexerRequest(indexer_url, submit_method, submit_params);
+
+    // TODO: keep polling the indexer until we get a result for the transaction
+    const transaction_id = transaction.id;
+
+    return { transaction_id };
+}
+
+export async function sendTransaction(wasm: tari_wallet_lib.InitOutput, request: JsonRpcRequest<Json[] | Record<string, Json>>) {
+    const params = request.params as SendTransactionRequest;
+    return await sendTransactionInternal(wasm, params);
+}
+
+export async function sendInstruction(wasm: tari_wallet_lib.InitOutput, request: JsonRpcRequest<Json[] | Record<string, Json>>) {
+    const params = request.params as SendInstructionRequest;
+    let { instructions, input_refs, required_substates, is_dry_run, fee, dump_account } = params;
+
+    if (dump_account) {
+        // TODO: the instruction type should accept strings as well
+        let key = [97, 95, 98, 117, 99, 107, 101, 116];
+
+        instructions.push({
+            PutLastInstructionOutputOnWorkspace: {
+                key
+            }
+        });
+        instructions.push({
+            CallMethod: {
+                component_address: dump_account,
+                method: "deposit",
+                args: [{ "Workspace": key }]
+            }
+        });
+    }
+
+    // automatically add fee payment instruction at the end
+    instructions.push({
+        CallMethod: {
+            component_address: dump_account,
+            method: "pay_fee",
+            args: [fee]
+        }
+    });
+
+    const sendTransactionRequest: SendTransactionRequest = {
+        instructions,
+        input_refs,
+        required_substates,
+        is_dry_run
+    };
+
+    return await sendTransactionInternal(wasm, sendTransactionRequest);
+}

--- a/packages/snap/src/types.ts
+++ b/packages/snap/src/types.ts
@@ -16,3 +16,12 @@ export type SendTransactionRequest = {
     required_substates: Object[],
     is_dry_run: boolean, 
 };
+
+export type SendInstructionRequest = {
+    instructions: Object[],
+    input_refs: Object[],
+    required_substates: Object[],
+    is_dry_run: boolean,
+    fee: number,
+    dump_account: string,
+};


### PR DESCRIPTION
The Tari snap now exposes the `sendInstruction` method, with similar behaviour to the `transactions.submit_instruction` method in the wallet daemon:
* Optional account parameter to deposit the resulting bucket of the last user instruction
* Automatically add `pay_fee` instruction afterwards