### PR TITLE
feat: NFT support in the wallet

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ To interact with Snaps, you will need to install [MetaMask Flask](https://metama
 
 You will also need a Tari network running, with an indexer. 
 
+For building the project, Node.js version 18 or superior is required.
 
 ## Getting Started
 
@@ -24,6 +25,7 @@ cd tari-snap
 Then you need to build the WebAssembly library used to build Tari transactions:
 ```shell
 cd tari_wallet_lib
+npm install
 npm run build
 ```
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,5 @@
 # TODO
+* Transaction IDs returned by the submit_transaction or sumbit_instruction methods do not match with the network. Hash calculation may be wrong.
 * Wait for transaction results and notify the user. We may need to use a snap cronjob to keep polling for pending transactions. Show both successful and rejected transactions.
 * Transfer dialog fixes:
     * Refresh max balance when the account balance changes

--- a/packages/site/src/components/MintDialog.tsx
+++ b/packages/site/src/components/MintDialog.tsx
@@ -1,0 +1,113 @@
+import Box from "@mui/material/Box";
+import Dialog from "@mui/material/Dialog";
+import DialogTitle from "@mui/material/DialogTitle";
+import Divider from "@mui/material/Divider";
+import ListItemText from "@mui/material/ListItemText";
+import MenuItem from "@mui/material/MenuItem";
+import Select from "@mui/material/Select";
+import Stack from "@mui/material/Stack";
+import TextField from "@mui/material/TextField";
+import Typography from "@mui/material/Typography";
+import React, { useEffect } from "react";
+import CloseIcon from '@mui/icons-material/Close';
+import IconButton from "@mui/material/IconButton";
+import Button from "@mui/material/Button";
+import { QRCodeSVG } from 'qrcode.react';
+import { ThemeFullWidthButton } from "./Buttons";
+import { copyToCliboard, truncateText } from "../utils/text";
+import { MetamaskActions } from "../hooks";
+import { defaultSnapOrigin } from "../config/snap";
+
+export interface MintDialogProps {
+    open: boolean;
+    onClose: () => void;
+}
+
+export function MintDialog(props: MintDialogProps) {
+    const { onClose, open } = props;
+
+    const [url, setUrl] = React.useState('');
+    const [name, setName] = React.useState('');
+
+    const handleClose = () => {
+        onClose();
+    };
+
+    const handleUrlChange = async (event) => {
+        setUrl(event.target.value);
+    };
+
+    const handleNameChange = async (event) => {
+        setName(event.target.value);
+    };
+
+    const handleMintClick = async () => {
+        try {
+            const metadata = [
+                { key: 'name', value: name },
+                { key: 'image_url', value: url },
+            ];
+            const response = await window.ethereum.request({
+                method: 'wallet_invokeSnap',
+                params: {
+                    snapId: defaultSnapOrigin,
+                    request: {
+                        method: 'mintAccountNft',
+                        params: {
+                            metadata,
+                            fee: 1,
+                        }
+                    }
+                },
+            });
+            console.log({ response });
+        } catch (e) {
+            console.error(e);
+            metamaskDispatch({ type: MetamaskActions.SetError, payload: e });
+        }
+
+        handleClose();
+    };
+
+    return (
+        <Dialog fullWidth={true} onClose={handleClose} open={open}>
+            <Box sx={{ padding: 4, borderRadius: 4 }}>
+                <Stack direction="row" justifyContent="space-between" spacing={2}>
+                    <Typography style={{ fontSize: 24 }}>Mint</Typography>
+                    <IconButton aria-label="copy" onClick={handleClose}>
+                        <CloseIcon style={{ fontSize: 24 }} />
+                    </IconButton>
+                </Stack>
+                <Divider sx={{ mt: 3, mb: 3 }} variant="middle" />
+                <Typography sx={{ mt: 4 }} style={{ fontSize: 14 }}>
+                    Image URL
+                </Typography>
+                <TextField sx={{ width: '100%' }}
+                    id="input-url"
+                    value={url}
+                    onChange={handleUrlChange}
+                    InputProps={{
+                        sx: { borderRadius: 4, mt: 1 },
+                    }}>
+                </TextField>
+                <Typography sx={{ mt: 3 }} style={{ fontSize: 14 }}>
+                    Name
+                </Typography>
+                <TextField sx={{ width: '100%' }}
+                    id="input-name"
+                    value={name}
+                    onChange={handleNameChange}
+                    InputProps={{
+                        sx: { borderRadius: 4, mt: 1 },
+                    }}></TextField>
+                <Stack direction="row" justifyContent="center" sx={{ mt: 3, width: '100%' }}>
+                    <ThemeFullWidthButton text="Mint" onClick={handleMintClick} />
+                </Stack>
+            </Box>
+        </Dialog >
+    );
+}
+
+function metamaskDispatch(arg0: { type: any; payload: any; }) {
+    throw new Error("Function not implemented.");
+}

--- a/packages/site/src/components/MintDialog.tsx
+++ b/packages/site/src/components/MintDialog.tsx
@@ -79,7 +79,7 @@ export function MintDialog(props: MintDialogProps) {
                     </IconButton>
                 </Stack>
                 <Box sx={{ textAlign: 'center'}}>
-                    <img style={{maxWidth: '50%', maxHeight: '50%'}} src={url}/>
+                    <img style={{maxWidth: '50%', maxHeight: '50%', borderRadius: '10px'}} src={url}/>
                 </Box>         
                 <Typography sx={{ mt: 4 }} style={{ fontSize: 14 }}>
                     Image URL

--- a/packages/site/src/components/MintDialog.tsx
+++ b/packages/site/src/components/MintDialog.tsx
@@ -78,6 +78,9 @@ export function MintDialog(props: MintDialogProps) {
                         <CloseIcon style={{ fontSize: 24 }} />
                     </IconButton>
                 </Stack>
+                <Box sx={{ textAlign: 'center'}}>
+                    <img style={{maxWidth: '50%', maxHeight: '50%'}} src={url}/>
+                </Box>         
                 <Divider sx={{ mt: 3, mb: 3 }} variant="middle" />
                 <Typography sx={{ mt: 4 }} style={{ fontSize: 14 }}>
                     Image URL

--- a/packages/site/src/components/MintDialog.tsx
+++ b/packages/site/src/components/MintDialog.tsx
@@ -1,20 +1,12 @@
 import Box from "@mui/material/Box";
 import Dialog from "@mui/material/Dialog";
-import DialogTitle from "@mui/material/DialogTitle";
-import Divider from "@mui/material/Divider";
-import ListItemText from "@mui/material/ListItemText";
-import MenuItem from "@mui/material/MenuItem";
-import Select from "@mui/material/Select";
 import Stack from "@mui/material/Stack";
 import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
 import React, { useEffect } from "react";
 import CloseIcon from '@mui/icons-material/Close';
 import IconButton from "@mui/material/IconButton";
-import Button from "@mui/material/Button";
-import { QRCodeSVG } from 'qrcode.react';
 import { ThemeFullWidthButton } from "./Buttons";
-import { copyToCliboard, truncateText } from "../utils/text";
 import { MetamaskActions } from "../hooks";
 import { defaultSnapOrigin } from "../config/snap";
 
@@ -89,7 +81,6 @@ export function MintDialog(props: MintDialogProps) {
                 <Box sx={{ textAlign: 'center'}}>
                     <img style={{maxWidth: '50%', maxHeight: '50%'}} src={url}/>
                 </Box>         
-                <Divider sx={{ mt: 3, mb: 3 }} variant="middle" />
                 <Typography sx={{ mt: 4 }} style={{ fontSize: 14 }}>
                     Image URL
                 </Typography>

--- a/packages/site/src/components/MintDialog.tsx
+++ b/packages/site/src/components/MintDialog.tsx
@@ -29,6 +29,14 @@ export function MintDialog(props: MintDialogProps) {
     const [url, setUrl] = React.useState('');
     const [name, setName] = React.useState('');
 
+    // clear dialog form each time it closes
+    useEffect(() => {
+        if (!open) {
+            setUrl('');
+            setName('');
+        }
+    }, [open]);
+
     const handleClose = () => {
         onClose();
     };

--- a/packages/site/src/components/SendNftDialog.tsx
+++ b/packages/site/src/components/SendNftDialog.tsx
@@ -11,6 +11,7 @@ import IconButton from "@mui/material/IconButton";
 import { MetaMaskContext, MetamaskActions, TariContext } from "../hooks";
 import { ThemeFullWidthButton } from "./Buttons";
 import { copyToCliboard, truncateText } from "../utils/text";
+import { defaultSnapOrigin } from "../config/snap";
 
 export interface SendNftDialogProps {
     nft: Object | null;
@@ -37,7 +38,28 @@ export function SendNftDialog(props: SendNftDialogProps) {
     };
 
     const handleSendClick = async () => {
-        console.log({ nft, recipient });
+        try {
+            const response = await window.ethereum.request({
+                method: 'wallet_invokeSnap',
+                params: {
+                    snapId: defaultSnapOrigin,
+                    request: {
+                        method: 'transferNft',
+                        params: {
+                            nft_address: nft.address,
+                            nft_id: nft.id,
+                            nft_resource: nft.collection,
+                            destination_public_key: recipient,
+                            fee: 1,
+                        }
+                    }
+                },
+            });
+            console.log({ response });
+        } catch (e) {
+            console.error(e);
+            metamaskDispatch({ type: MetamaskActions.SetError, payload: e });
+        }
         handleClose();
     };
 

--- a/packages/site/src/components/SendNftDialog.tsx
+++ b/packages/site/src/components/SendNftDialog.tsx
@@ -1,0 +1,104 @@
+import Box from "@mui/material/Box";
+import Dialog from "@mui/material/Dialog";
+import Divider from "@mui/material/Divider";
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import Stack from "@mui/material/Stack";
+import TextField from "@mui/material/TextField";
+import Typography from "@mui/material/Typography";
+import React, { useContext, useEffect } from "react";
+import CloseIcon from '@mui/icons-material/Close';
+import IconButton from "@mui/material/IconButton";
+import { MetaMaskContext, MetamaskActions, TariContext } from "../hooks";
+import { ThemeFullWidthButton } from "./Buttons";
+import { copyToCliboard, truncateText } from "../utils/text";
+
+export interface SendNftDialogProps {
+    nft: Object | null;
+    open: boolean;
+    onClose: () => void;
+}
+
+export function SendNftDialog(props: SendNftDialogProps) {
+    const [metamaskState, metamaskDispatch] = useContext(MetaMaskContext);
+    const [tariState, tariDispatch] = useContext(TariContext);
+
+    const { nft, onClose, open } = props;
+    const [recipient, setRecipient] = React.useState('');
+
+    // clear dialog form each time it closes
+    useEffect(() => {
+        if (!open) {
+            setRecipient('');
+        }
+    }, [open]);
+
+    const handleRecipientChange = async (event) => {
+        setRecipient(event.target.value);
+    };
+
+    const handleSendClick = async () => {
+        console.log({ nft, recipient });
+        handleClose();
+    };
+
+    const handleClose = () => {
+        onClose();
+    };
+
+    const handleCopyClick = async (text) => {
+        copyToCliboard(text);
+    };
+
+    const shouldRender = () => {
+        return nft
+    }
+
+    if (!shouldRender()) {
+        return null;
+    }
+
+    return (
+        <Dialog fullWidth={true} onClose={handleClose} open={open}>
+            <Box sx={{ padding: 5, borderRadius: 4 }}>
+                <Stack direction="row" justifyContent="space-between" spacing={2}>
+                    <Typography style={{ fontSize: 24 }}>Send</Typography>
+                    <IconButton aria-label="copy" onClick={handleClose}>
+                        <CloseIcon style={{ fontSize: 24 }} />
+                    </IconButton>
+                </Stack>
+                <Divider sx={{ mt: 3, mb: 3 }} variant="middle" />
+                <Box sx={{ textAlign: 'center' }}>
+                    <img style={{ maxWidth: '50%', maxHeight: '50%', borderRadius: '10px' }} src={nft.metadata.image_url} />
+                </Box>
+                <Stack direction="column" alignItems="center" justifyContent="center" sx={{mt:2}}>
+                    <Typography alignSelf="center" style={{ fontSize: 18 }} >
+                        {truncateText(nft.metadata.name, 20)}
+                    </Typography>
+                    <Stack direction="row" alignItems="center" justifyContent="center">
+
+                        <Typography style={{ fontSize: 15 }} >
+                            {truncateText(nft.address, 20)}
+                        </Typography>
+                        <IconButton aria-label="copy" onClick={() => handleCopyClick(nft.address)}>
+                            <ContentCopyIcon />
+                        </IconButton>
+                    </Stack>
+
+                </Stack>
+
+                <Typography sx={{ mt: 4 }} style={{ fontSize: 14 }}>
+                    Recipient
+                </Typography>
+                <TextField sx={{ mt: 1, width: '100%' }} id="recipient" placeholder="0"
+                    onChange={handleRecipientChange}
+                    InputProps={{
+                        sx: { borderRadius: 4 },
+                    }}>
+                </TextField>
+                <Stack direction="row" justifyContent="center" sx={{ mt: 4, width: '100%' }}>
+                    <ThemeFullWidthButton text="Send" onClick={async () => { await handleSendClick(); }} />
+                </Stack>
+            </Box>
+        </Dialog >
+    );
+}

--- a/packages/site/src/components/sections/Balances.tsx
+++ b/packages/site/src/components/sections/Balances.tsx
@@ -42,11 +42,16 @@ function Balances() {
                 });
             }
 
-            if (!data || !data.balances) {
+            if (!data || !data.resources) {
                 return [];  
             }
 
-            return data.balances;
+            console.log({resources: data.resources});
+
+            let fungibles = data.resources
+                .filter(r => r.type === 'fungible' || r.type === 'confidential');
+
+            return fungibles;
         } catch (e) {
             console.error(e);
             metamaskDispatch({ type: MetamaskActions.SetError, payload: e });
@@ -64,7 +69,7 @@ function Balances() {
         }
 
         // we keep polling for balances to keep them updated
-        setTimeout(async () => { await refreshAccountBalances() }, 4000);
+        setTimeout(async () => { await refreshAccountBalances() }, 5000);
     }
 
     useEffect(() => {

--- a/packages/site/src/components/sections/Balances.tsx
+++ b/packages/site/src/components/sections/Balances.tsx
@@ -46,8 +46,6 @@ function Balances() {
                 return [];  
             }
 
-            console.log({resources: data.resources});
-
             let fungibles = data.resources
                 .filter(r => r.type === 'fungible' || r.type === 'confidential');
 

--- a/packages/site/src/components/sections/Nfts.tsx
+++ b/packages/site/src/components/sections/Nfts.tsx
@@ -45,21 +45,31 @@ function Nfts() {
                 .filter(res => res.type === 'nonfungible')
                 .map(res => {
                     const collection = res.resource_address;
-                    const items = res.token_ids.map(id => `${collection} nft_${id}`);
+                    const items = res.token_ids.map(id => {
+                        return {
+                            address: `${collection} nft_${id}`,
+                            collection,
+                            id
+                        }
+                    });
                     return items;
                 })
                 .flat();
 
-            const nft_contents = await Promise.all(nft_addresses.map(async (addr: any) => {
-                return await getSubstate(addr);
+            const nft_contents = await Promise.all(nft_addresses.map(async (nft: any) => {
+                const content = await getSubstate(nft.address);
+                return {
+                    ...nft,
+                    content
+                }
             }));
 
             const substates = nft_contents
-                .filter(content => content.result)
-                .map(content => {
-                    const address = content.result.address;
-                    const metadata = content.result.substate_contents.substate.NonFungible.data['@@TAGGED@@'][1];
-                    return { address, metadata };
+                .filter(nft => nft.content.result)
+                .map(nft => {
+                    //const address = content.result.address;
+                    const metadata = nft.content.result.substate_contents.substate.NonFungible.data['@@TAGGED@@'][1];
+                    return { ...nft, metadata };
                 });
 
             return substates;

--- a/packages/site/src/components/sections/Nfts.tsx
+++ b/packages/site/src/components/sections/Nfts.tsx
@@ -20,6 +20,8 @@ import ImageListItemBar from '@mui/material/ImageListItemBar';
 import { MintDialog } from '../MintDialog';
 import { styled } from '@mui/material/styles';
 import Card from '@mui/material/Card';
+import StartIcon from '@mui/icons-material/Start';
+import { SendNftDialog } from '../SendNftDialog';
 
 function Nfts() {
     const [metamaskState, metamaskDispatch] = useContext(MetaMaskContext);
@@ -27,6 +29,8 @@ function Nfts() {
 
     const [mintDialogOpen, setMintDialogOpen] = React.useState(false);
     const [receiveDialogOpen, setReceiveDialogOpen] = React.useState(false);
+    const [selectedNft, setSelectedNft] = React.useState(null);
+    const [sendDialogOpen, setSendDialogOpen] = React.useState(false);
     const [nfts, setNfts] = React.useState([]);
 
     const getNfts = async () => {
@@ -53,8 +57,9 @@ function Nfts() {
             const substates = nft_contents
                 .filter(content => content.result)
                 .map(content => {
-                    // metadata of the nft
-                    return content.result.substate_contents.substate.NonFungible.data['@@TAGGED@@'][1];
+                    const address = content.result.address;
+                    const metadata = content.result.substate_contents.substate.NonFungible.data['@@TAGGED@@'][1];
+                    return { address, metadata };
                 });
 
             return substates;
@@ -97,6 +102,15 @@ function Nfts() {
         copyToCliboard(text);
     };
 
+    const handleSendOpen = (nft) => {
+        setSelectedNft(nft);
+        setSendDialogOpen(true);
+    };
+
+    const handleSendClose = () => {
+        setSendDialogOpen(false);
+    };
+
     return (
         <Container>
             {tari.account?.public_key ?
@@ -134,11 +148,16 @@ function Nfts() {
                                 <Grid item xs={3}>
                                     <Stack direction="column" sx={{padding: 1}}>
                                         <Box sx={{ textAlign: 'center'}}>
-                                            <img style={{borderRadius: 8, width: '100%'}} src={nft.image_url}/>
+                                            <img style={{borderRadius: 8, width: '100%'}} src={nft.metadata.image_url}/>
                                         </Box>
-                                        <Typography sx={{mt: 0.5}} style={{ fontSize: 16 }} >
-                                            {nft.name}
-                                        </Typography>
+                                        <Stack direction="row" spacing={2} sx={{mt: 0.5}}>
+                                            <Typography style={{ fontSize: 16 }} >
+                                                {nft.metadata.name}
+                                            </Typography>
+                                            <IconButton aria-label="send" sx={{padding:0, minHeight: 0}} onClick={() => handleSendOpen(nft)}>
+                                                <StartIcon style={{ fontSize: 16 }}/>
+                                            </IconButton>
+                                        </Stack>
                                     </Stack>
                                 </Grid>
                             ))}
@@ -152,6 +171,11 @@ function Nfts() {
                         address={tari.account?.public_key}
                         open={receiveDialogOpen}
                         onClose={handleReceiveClose}
+                    />
+                    <SendNftDialog
+                        nft={selectedNft}
+                        open={sendDialogOpen}
+                        onClose={handleSendClose}
                     />
                 </Container>)
                 : (<div />)}

--- a/packages/site/src/components/sections/Nfts.tsx
+++ b/packages/site/src/components/sections/Nfts.tsx
@@ -18,6 +18,8 @@ import ImageList from '@mui/material/ImageList';
 import ImageListItem from '@mui/material/ImageListItem';
 import ImageListItemBar from '@mui/material/ImageListItemBar';
 import { MintDialog } from '../MintDialog';
+import { styled } from '@mui/material/styles';
+import Card from '@mui/material/Card';
 
 function Nfts() {
     const [metamaskState, metamaskDispatch] = useContext(MetaMaskContext);
@@ -127,25 +129,19 @@ function Nfts() {
                                 Owned NFTs
                             </Typography>
                         </Stack>
-                        <Grid container spacing={5}>
-                            <Grid item xs={12}>
-                                <ImageList cols={4} gap={8}>
-                                    {nfts.map((nft) => (
-                                        <ImageListItem>
-                                            <img
-                                                src={`${nft.image_url}?size=248&fit=fill&auto=format`}
-                                                srcSet={`${nft.image_url}?size=248&fit=fill&auto=format&dpr=2 4x`}
-                                                alt={nft.name}
-                                                loading="lazy"
-                                            />
-                                            <ImageListItemBar
-                                                title={nft.name}
-                                                position="below"
-                                            />
-                                        </ImageListItem>
-                                    ))}
-                                </ImageList>
-                            </Grid>
+                        <Grid container spacing={2} sx={{ mt: 3}}>
+                            {nfts.map((nft) => (
+                                <Grid item xs={3}>
+                                    <Stack direction="column" sx={{padding: 1}}>
+                                        <Box sx={{ textAlign: 'center'}}>
+                                            <img style={{borderRadius: 8, width: '100%'}} src={nft.image_url}/>
+                                        </Box>
+                                        <Typography sx={{mt: 0.5}} style={{ fontSize: 16 }} >
+                                            {nft.name}
+                                        </Typography>
+                                    </Stack>
+                                </Grid>
+                            ))}
                         </Grid>
                     </Paper>
                     <MintDialog

--- a/packages/site/src/components/sections/Nfts.tsx
+++ b/packages/site/src/components/sections/Nfts.tsx
@@ -1,0 +1,109 @@
+import { useContext } from 'react';
+import { MetaMaskContext, MetamaskActions, TariContext } from '../../hooks';
+import Container from '@mui/material/Container';
+import Typography from '@mui/material/Typography';
+import Paper from '@mui/material/Paper';
+import Stack from '@mui/material/Stack';
+import React from 'react';
+import Box from '@mui/material/Box';
+import { ThemeButton } from '../Buttons';
+import { defaultSnapOrigin } from '../../config/snap';
+import { ReceiveDialog } from '../ReceiveDialog';
+import IconButton from '@mui/material/IconButton';
+import { copyToCliboard } from '../../utils/text';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+
+function Nfts() {
+    const [metamaskState, metamaskDispatch] = useContext(MetaMaskContext);
+    const [tari, tariDispatch] = useContext(TariContext);
+
+    const [sendDialogOpen, setSendDialogOpen] = React.useState(false);
+    const [receiveDialogOpen, setReceiveDialogOpen] = React.useState(false);
+
+    const handleMint = async () => {
+        try {
+            const metadata = [
+                { key: 'name', value: 'Test NFT' },
+                { key: 'image_url', value: 'https://img.freepik.com/free-vector/hand-drawn-nft-style-ape-illustration_23-2149622024.jpg' },
+            ];
+            const response = await window.ethereum.request({
+                method: 'wallet_invokeSnap',
+                params: {
+                    snapId: defaultSnapOrigin,
+                    request: {
+                        method: 'mintAccountNft',
+                        params: {
+                            metadata,
+                            fee: 1,
+                        }
+                    }
+                },
+            });
+            console.log({ response });
+        } catch (e) {
+            console.error(e);
+            metamaskDispatch({ type: MetamaskActions.SetError, payload: e });
+        }
+    }
+
+    const handleSendOpen = () => {
+        setSendDialogOpen(true);
+    };
+
+    const handleSendClose = () => {
+        setSendDialogOpen(false);
+    };
+
+    const handleReceiveOpen = () => {
+        setReceiveDialogOpen(true);
+    };
+
+    const handleReceiveClose = () => {
+        setReceiveDialogOpen(false);
+    };
+
+    const handleCopyClick = async (text: string | undefined) => {
+        copyToCliboard(text);
+    };
+
+    return (
+        <Container>
+        {tari.account?.public_key ?
+            (<Container>
+                <Paper variant="outlined" elevation={0} sx={{ mt: 4, padding: 2, paddingLeft: 4, paddingRight: 4, borderRadius: 4 }}>
+                    <Stack direction="row" justifyContent="space-between" spacing={2}>
+                            <Box>
+                                <Typography style={{ fontSize: 12 }} >
+                                    Account address
+                                </Typography>
+                                <Stack direction="row" alignItems="center" justifyContent="center">
+                                    <Typography style={{ fontSize: 15 }} >
+                                        {tari.account?.public_key}
+                                    </Typography>
+                                    <IconButton aria-label="copy" onClick={() => handleCopyClick(tari.account?.public_key)}>
+                                        <ContentCopyIcon />
+                                    </IconButton>
+                                </Stack>
+                            </Box>
+                        <Stack direction="row" spacing={2}>
+                            <ThemeButton text="Mint" onClick={async () => { await handleMint(); }}/>
+                            <ThemeButton text="Receive" onClick={handleReceiveOpen}/>
+                        </Stack>
+                    </Stack>
+    
+                </Paper>
+                <Paper variant="outlined" elevation={0} sx={{ mt: 4, padding: 2, paddingLeft: 4, paddingRight: 4, borderRadius: 4 }}>
+                    No NFTs owned
+                </Paper>
+                <ReceiveDialog
+                        address={tari.account?.public_key}
+                        open={receiveDialogOpen}
+                        onClose={handleReceiveClose}
+                    />
+            </Container>) 
+            : (<div/>) }
+    </Container>
+    );
+}
+
+export default Nfts;

--- a/packages/site/src/components/sections/Nfts.tsx
+++ b/packages/site/src/components/sections/Nfts.tsx
@@ -17,11 +17,13 @@ import Grid from '@mui/material/Grid';
 import ImageList from '@mui/material/ImageList';
 import ImageListItem from '@mui/material/ImageListItem';
 import ImageListItemBar from '@mui/material/ImageListItemBar';
+import { MintDialog } from '../MintDialog';
 
 function Nfts() {
     const [metamaskState, metamaskDispatch] = useContext(MetaMaskContext);
     const [tari, tariDispatch] = useContext(TariContext);
 
+    const [mintDialogOpen, setMintDialogOpen] = React.useState(false);
     const [receiveDialogOpen, setReceiveDialogOpen] = React.useState(false);
     const [nfts, setNfts] = React.useState([]);
 
@@ -64,7 +66,6 @@ function Nfts() {
     const refreshNfts = async () => {
         const currentNfts = await getNfts();
         setNfts(currentNfts);
-        console.log({ currentNfts });
 
         // we keep polling for nfts to keep them updated
         setTimeout(async () => { await refreshNfts() }, 10000);
@@ -74,31 +75,13 @@ function Nfts() {
         refreshNfts();
     }, []);
 
-    const handleMint = async () => {
-        try {
-            const metadata = [
-                { key: 'name', value: 'Test NFT' },
-                { key: 'image_url', value: 'https://img.freepik.com/free-vector/hand-drawn-nft-style-ape-illustration_23-2149622024.jpg' },
-            ];
-            const response = await window.ethereum.request({
-                method: 'wallet_invokeSnap',
-                params: {
-                    snapId: defaultSnapOrigin,
-                    request: {
-                        method: 'mintAccountNft',
-                        params: {
-                            metadata,
-                            fee: 1,
-                        }
-                    }
-                },
-            });
-            console.log({ response });
-        } catch (e) {
-            console.error(e);
-            metamaskDispatch({ type: MetamaskActions.SetError, payload: e });
-        }
-    }
+    const handleMintOpen = () => {
+        setMintDialogOpen(true);
+    };
+
+    const handleMintClose = () => {
+        setMintDialogOpen(false);
+    };
 
     const handleReceiveOpen = () => {
         setReceiveDialogOpen(true);
@@ -132,7 +115,7 @@ function Nfts() {
                                 </Stack>
                             </Box>
                             <Stack direction="row" spacing={2}>
-                                <ThemeButton text="Mint" onClick={async () => { await handleMint(); }} />
+                                <ThemeButton text="Mint" onClick={handleMintOpen} />
                                 <ThemeButton text="Receive" onClick={handleReceiveOpen} />
                             </Stack>
                         </Stack>
@@ -165,6 +148,10 @@ function Nfts() {
                             </Grid>
                         </Grid>
                     </Paper>
+                    <MintDialog
+                        open={mintDialogOpen}
+                        onClose={handleMintClose}
+                    />
                     <ReceiveDialog
                         address={tari.account?.public_key}
                         open={receiveDialogOpen}

--- a/packages/site/src/components/sections/Nfts.tsx
+++ b/packages/site/src/components/sections/Nfts.tsx
@@ -13,13 +13,17 @@ import IconButton from '@mui/material/IconButton';
 import { copyToCliboard } from '../../utils/text';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import { getAccountData, getSubstate } from '../../utils/snap';
+import Grid from '@mui/material/Grid';
+import ImageList from '@mui/material/ImageList';
+import ImageListItem from '@mui/material/ImageListItem';
+import ImageListItemBar from '@mui/material/ImageListItemBar';
 
 function Nfts() {
     const [metamaskState, metamaskDispatch] = useContext(MetaMaskContext);
     const [tari, tariDispatch] = useContext(TariContext);
 
-    const [receiveDialogOpen, setReceiveDialogOpen] = React.useState(false); 
-    const [nfts, setNfts] = React.useState([]); 
+    const [receiveDialogOpen, setReceiveDialogOpen] = React.useState(false);
+    const [nfts, setNfts] = React.useState([]);
 
     const getNfts = async () => {
         try {
@@ -60,7 +64,7 @@ function Nfts() {
     const refreshNfts = async () => {
         const currentNfts = await getNfts();
         setNfts(currentNfts);
-        console.log({currentNfts});
+        console.log({ currentNfts });
 
         // we keep polling for nfts to keep them updated
         setTimeout(async () => { await refreshNfts() }, 10000);
@@ -110,10 +114,10 @@ function Nfts() {
 
     return (
         <Container>
-        {tari.account?.public_key ?
-            (<Container>
-                <Paper variant="outlined" elevation={0} sx={{ mt: 4, padding: 2, paddingLeft: 4, paddingRight: 4, borderRadius: 4 }}>
-                    <Stack direction="row" justifyContent="space-between" spacing={2}>
+            {tari.account?.public_key ?
+                (<Container>
+                    <Paper variant="outlined" elevation={0} sx={{ mt: 4, padding: 2, paddingLeft: 4, paddingRight: 4, borderRadius: 4 }}>
+                        <Stack direction="row" justifyContent="space-between" spacing={2}>
                             <Box>
                                 <Typography style={{ fontSize: 12 }} >
                                     Account address
@@ -127,24 +131,48 @@ function Nfts() {
                                     </IconButton>
                                 </Stack>
                             </Box>
-                        <Stack direction="row" spacing={2}>
-                            <ThemeButton text="Mint" onClick={async () => { await handleMint(); }}/>
-                            <ThemeButton text="Receive" onClick={handleReceiveOpen}/>
+                            <Stack direction="row" spacing={2}>
+                                <ThemeButton text="Mint" onClick={async () => { await handleMint(); }} />
+                                <ThemeButton text="Receive" onClick={handleReceiveOpen} />
+                            </Stack>
                         </Stack>
-                    </Stack>
-    
-                </Paper>
-                <Paper variant="outlined" elevation={0} sx={{ mt: 4, padding: 2, paddingLeft: 4, paddingRight: 4, borderRadius: 4 }}>
-                    No NFTs owned
-                </Paper>
-                <ReceiveDialog
+
+                    </Paper>
+                    <Paper variant="outlined" elevation={0} sx={{ mt: 4, padding: 2, paddingLeft: 4, paddingRight: 4, borderRadius: 4 }}>
+                        <Stack direction="column" justifyContent="flex-start" spacing={2}>
+                            <Typography style={{ fontSize: 24 }} >
+                                Owned NFTs
+                            </Typography>
+                        </Stack>
+                        <Grid container spacing={5}>
+                            <Grid item xs={12}>
+                                <ImageList cols={4} gap={8}>
+                                    {nfts.map((nft) => (
+                                        <ImageListItem>
+                                            <img
+                                                src={`${nft.image_url}?size=248&fit=fill&auto=format`}
+                                                srcSet={`${nft.image_url}?size=248&fit=fill&auto=format&dpr=2 4x`}
+                                                alt={nft.name}
+                                                loading="lazy"
+                                            />
+                                            <ImageListItemBar
+                                                title={nft.name}
+                                                position="below"
+                                            />
+                                        </ImageListItem>
+                                    ))}
+                                </ImageList>
+                            </Grid>
+                        </Grid>
+                    </Paper>
+                    <ReceiveDialog
                         address={tari.account?.public_key}
                         open={receiveDialogOpen}
                         onClose={handleReceiveClose}
                     />
-            </Container>) 
-            : (<div/>) }
-    </Container>
+                </Container>)
+                : (<div />)}
+        </Container>
     );
 }
 

--- a/packages/site/src/components/sections/Transactions.tsx
+++ b/packages/site/src/components/sections/Transactions.tsx
@@ -60,7 +60,7 @@ function Transactions() {
         }
 
         // we keep polling for transactions to keep them updated
-        setTimeout(async () => { await refreshTransactions() }, 4000);
+        setTimeout(async () => { await refreshTransactions() }, 5000);
     }
 
     useEffect(() => {

--- a/packages/site/src/pages/index.tsx
+++ b/packages/site/src/pages/index.tsx
@@ -1,58 +1,21 @@
-import { useContext, useEffect } from 'react';
-import { MetamaskActions, MetaMaskContext, TariActions, TariContext, AccountState } from '../hooks';
-
-import {
-    connectSnap,
-    getSnap,
-    isLocalSnap,
-    shouldDisplayReconnectButton,
-} from '../utils';
-import {
-    ConnectButton,
-    InstallFlaskButton,
-    ReconnectButton,
-    Card,
-    ThemeButton,
-} from '../components';
-import { defaultSnapOrigin } from '../config';
-
 import React from 'react';
 import Balances from '../components/sections/Balances';
 import Transactions from '../components/sections/Transactions';
-import Tabs from '@mui/material/Tabs';
-import Tab from '@mui/material/Tab';
 import Box from '@mui/material/Box';
-import Typography from '@mui/material/Typography';
 import Stack from '@mui/material/Stack';
 import MenuItem from '@mui/material/MenuItem';
-import Button from '@mui/material/Button';
+import Nfts from '../components/sections/NFTs';
 
 
 function Index() {
-    const [metamaskState, metamaskDispatch] = useContext(MetaMaskContext);
-    const [tari, tariDispatch] = useContext(TariContext);
-
     const [tab, setTab] = React.useState(0);
-
-    interface TabPanelProps {
-        children?: React.ReactNode;
-        index: number;
-        value: number;
-    }
-
-    const selectBalances = () => {
-        setTab(0);
-    };
-
-    const selectTransactions = () => {
-        setTab(1);
-    };
 
     return (
         <Box sx={{ mt: 4 }}>
             <Stack direction='row' alignItems="center" justifyContent="center">
-                <MenuItem sx={{ fontSize: 20, fontWeight: tab == 0 ? 'bold' : 'default' }} onClick={selectBalances}>Balances</MenuItem>
-                <MenuItem sx={{ fontSize: 20, fontWeight: tab == 1 ? 'bold' : 'default' }} onClick={selectTransactions}>Transactions</MenuItem>
+                <MenuItem sx={{ fontSize: 20, fontWeight: tab == 0 ? 'bold' : 'default' }} onClick={() => {setTab(0)}}>Balances</MenuItem>
+                <MenuItem sx={{ fontSize: 20, fontWeight: tab == 1 ? 'bold' : 'default' }} onClick={() => {setTab(1)}}>Transactions</MenuItem>
+                <MenuItem sx={{ fontSize: 20, fontWeight: tab == 2 ? 'bold' : 'default' }} onClick={() => {setTab(2)}}>NFTs</MenuItem>
             </Stack>
 
             {/* Balances */}
@@ -66,6 +29,13 @@ function Index() {
             {tab === 1 && (
                 <Box >
                     <Transactions />
+                </Box>
+            )}
+
+            {/* NFTs */}
+            {tab === 2 && (
+                <Box >
+                    <Nfts />
                 </Box>
             )}
         </Box>

--- a/packages/site/src/utils/snap.ts
+++ b/packages/site/src/utils/snap.ts
@@ -93,6 +93,21 @@ export const getFreeTestCoins = async (amount: number, fee: number) => {
   });
 };
 
+export const getSubstate = async (substate_address: string) => {
+  return window.ethereum.request({
+    method: 'wallet_invokeSnap',
+    params: {
+      snapId: defaultSnapOrigin,
+      request: {
+        method: 'getSubstate',
+        params: {
+          substate_address
+        }
+      }
+    },
+  });
+};
+
 export const isLocalSnap = (snapId: string) => snapId.startsWith('local:');
 
 

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/template-snap-monorepo.git"
   },
   "source": {
-    "shasum": "t/qyr35+uVoS+wtH0+PwdwCrxVjcq6Y9JYQeVngYIVU=",
+    "shasum": "2xlazfYBKDzd1sN9kvTecO/HFCM6M1BmmN59tS7febs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/template-snap-monorepo.git"
   },
   "source": {
-    "shasum": "VuzgwcsKtoMGs5lw4nSgO8eh8vW0h4x4MsFhMpeQjwE=",
+    "shasum": "pyJVffeSLfSit0htY3raWGsDtmNZJ4gjVe4lbVvbV2U=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/template-snap-monorepo.git"
   },
   "source": {
-    "shasum": "VK8Y00a5SJXYA6IOoT+NI+BEdIyTfWgg+h7tC/4xjOM=",
+    "shasum": "X5QTcHeo7qWSvu7G/JXhMJYuw1x++8Z+jlttHzSy6jY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/template-snap-monorepo.git"
   },
   "source": {
-    "shasum": "2xlazfYBKDzd1sN9kvTecO/HFCM6M1BmmN59tS7febs=",
+    "shasum": "g8CvVnQG4aMwa6l6oYe7mzmEIM74X+77z8Jn1ofEfgY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/template-snap-monorepo.git"
   },
   "source": {
-    "shasum": "X5QTcHeo7qWSvu7G/JXhMJYuw1x++8Z+jlttHzSy6jY=",
+    "shasum": "VuzgwcsKtoMGs5lw4nSgO8eh8vW0h4x4MsFhMpeQjwE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/template-snap-monorepo.git"
   },
   "source": {
-    "shasum": "pyJVffeSLfSit0htY3raWGsDtmNZJ4gjVe4lbVvbV2U=",
+    "shasum": "t/qyr35+uVoS+wtH0+PwdwCrxVjcq6Y9JYQeVngYIVU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/template-snap-monorepo.git"
   },
   "source": {
-    "shasum": "RPx1N+cYy1db0ond5XAea6GXxmwxeXYQnszMf225zZM=",
+    "shasum": "VK8Y00a5SJXYA6IOoT+NI+BEdIyTfWgg+h7tC/4xjOM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/index.ts
+++ b/packages/snap/src/index.ts
@@ -1,9 +1,9 @@
 import { Json, JsonRpcRequest, OnRpcRequestHandler } from '@metamask/snaps-types';
 import { heading, panel, text } from '@metamask/snaps-ui';
 import * as tari_wallet_lib from './tari_wallet_lib';
-import { decode_resource_address, decode_vault_id, int_array_to_hex, sendIndexerRequest, substateExists } from './tari_indexer_client';
+import { decode_resource_address, decode_vault_id, getSubstate, int_array_to_hex, sendIndexerRequest, substateExists } from './tari_indexer_client';
 import { getRistrettoKeyPair } from './keys';
-import { GetFreeTestCoinsRequest, TransferRequest } from './types';
+import { GetFreeTestCoinsRequest, GetSubstateRequest, TransferRequest } from './types';
 import { sendInstruction, sendTransaction } from './transactions';
 import { mintAccountNft } from './nfts';
 
@@ -246,6 +246,15 @@ async function getFreeTestCoins(request: JsonRpcRequest<Json[] | Record<string, 
   return { transaction_id };
 }
 
+async function getSubstateHandler(request: JsonRpcRequest<Json[] | Record<string, Json>>) {
+  const params = request.params as GetSubstateRequest;
+  const { substate_address } = params;
+
+  const indexer_url = process.env.TARI_INDEXER_URL;
+
+  return await getSubstate(indexer_url, substate_address);
+}
+
 /**
  * Handle incoming JSON-RPC requests, sent through `wallet_invokeSnap`.
  *
@@ -276,6 +285,8 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ origin, request }) => 
       return sendInstruction(wasm, request);
     case 'mintAccountNft':
       return mintAccountNft(wasm, request);
+    case 'getSubstate':
+      return getSubstateHandler(request);
     default:
       throw new Error('Method not found.');
   }

--- a/packages/snap/src/index.ts
+++ b/packages/snap/src/index.ts
@@ -5,7 +5,7 @@ import { decode_resource_address, decode_vault_id, getSubstate, int_array_to_hex
 import { getRistrettoKeyPair } from './keys';
 import { GetFreeTestCoinsRequest, GetSubstateRequest, TransferRequest } from './types';
 import { sendInstruction, sendTransaction } from './transactions';
-import { mintAccountNft } from './nfts';
+import { mintAccountNft, transferNft } from './nfts';
 
 // Due to a bug of how brfs interacts with babel, we need to use require() syntax instead of import pattern
 // https://github.com/browserify/brfs/issues/39
@@ -285,6 +285,8 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ origin, request }) => 
       return sendInstruction(wasm, request);
     case 'mintAccountNft':
       return mintAccountNft(wasm, request);
+    case 'transferNft':
+      return transferNft(wasm, request);
     case 'getSubstate':
       return getSubstateHandler(request);
     default:

--- a/packages/snap/src/nfts.ts
+++ b/packages/snap/src/nfts.ts
@@ -1,0 +1,61 @@
+import { Json, JsonRpcRequest } from '@metamask/snaps-types';
+import * as tari_wallet_lib from './tari_wallet_lib';
+import { substateExists } from './tari_indexer_client';
+import { getRistrettoKeyPair } from './keys';
+import { SendInstructionRequest } from './types';
+import { sendInstructionInternal } from './transactions';
+
+const ACCOUNT_NFT_TEMPLATE = '0000000000000000000000000000000000000000000000000000000000000001';
+
+export type MintAccountNftRequest = {
+  metadata: Object,
+  fee: number,
+};
+
+export async function mintAccountNft(wasm: tari_wallet_lib.InitOutput, request: JsonRpcRequest<Json[] | Record<string, Json>>) {
+  const params = request.params as MintAccountNftRequest;
+  const { metadata, fee } = params;
+
+  const accountIndex = 0;
+  const { public_key } = await getRistrettoKeyPair(accountIndex);
+  const account_component_address = tari_wallet_lib.get_account_component_address(public_key);
+  const nft_component_address = tari_wallet_lib.get_account_nft_component_address(public_key);
+  let instructions = [];
+
+  // create the NFT holding component if it does not exist already
+  const indexer_url = process.env.TARI_INDEXER_URL;
+  let account_nft_exists = await substateExists(indexer_url, nft_component_address);
+  if (!account_nft_exists) {
+      const owner_token = await tari_wallet_lib.get_owner_token(public_key);
+      instructions.push({
+        CallFunction: {
+          template_address: ACCOUNT_NFT_TEMPLATE,
+          function: "create",
+          args: [{ "Literal": owner_token }]
+        }
+      });
+  }
+
+  // build and send the mint transaction
+  let encoded_metadata = tari_wallet_lib.encode_metadata(metadata);
+  let sendInstructionRequest: SendInstructionRequest = {
+    instructions: [
+      ...instructions,
+      {
+        CallMethod: {
+          component_address: nft_component_address,
+          method: "mint",
+          args: [{ "Literal": encoded_metadata }]
+        }
+      }
+    ],
+    input_refs: [],
+    required_substates: [ { address: account_component_address, version: null}],
+    is_dry_run: false,
+    fee,
+    dump_account: account_component_address,
+  };
+
+  const result = await sendInstructionInternal(wasm, sendInstructionRequest);
+  return { result }
+}

--- a/packages/snap/src/nfts.ts
+++ b/packages/snap/src/nfts.ts
@@ -26,14 +26,20 @@ export async function mintAccountNft(wasm: tari_wallet_lib.InitOutput, request: 
   const indexer_url = process.env.TARI_INDEXER_URL;
   let account_nft_exists = await substateExists(indexer_url, nft_component_address);
   if (!account_nft_exists) {
-      const owner_token = await tari_wallet_lib.get_owner_token(public_key);
-      instructions.push({
-        CallFunction: {
-          template_address: ACCOUNT_NFT_TEMPLATE,
-          function: "create",
-          args: [{ "Literal": owner_token }]
-        }
-      });
+    const owner_token = await tari_wallet_lib.get_owner_token(public_key);
+    instructions.push({
+      CallFunction: {
+        template_address: ACCOUNT_NFT_TEMPLATE,
+        function: "create",
+        args: [{ "Literal": owner_token }]
+      }
+    });
+  }
+
+  // include the input substates of the transaction (account and nft component)
+  let required_substates = [{ address: account_component_address, version: null }];
+  if (account_nft_exists) {
+    required_substates.push({ address: nft_component_address, version: null });
   }
 
   // build and send the mint transaction
@@ -50,7 +56,7 @@ export async function mintAccountNft(wasm: tari_wallet_lib.InitOutput, request: 
       }
     ],
     input_refs: [],
-    required_substates: [ { address: account_component_address, version: null}],
+    required_substates,
     is_dry_run: false,
     fee,
     dump_account: account_component_address,

--- a/packages/snap/src/nfts.ts
+++ b/packages/snap/src/nfts.ts
@@ -2,10 +2,11 @@ import { Json, JsonRpcRequest } from '@metamask/snaps-types';
 import * as tari_wallet_lib from './tari_wallet_lib';
 import { substateExists } from './tari_indexer_client';
 import { getRistrettoKeyPair } from './keys';
-import { SendInstructionRequest } from './types';
-import { sendInstructionInternal } from './transactions';
+import { SendInstructionRequest, SendTransactionRequest } from './types';
+import { sendInstructionInternal, sendTransactionInternal } from './transactions';
 
 const ACCOUNT_NFT_TEMPLATE = '0000000000000000000000000000000000000000000000000000000000000001';
+const ACCOUNT_TEMPLATE = '0000000000000000000000000000000000000000000000000000000000000000';
 
 export type MintAccountNftRequest = {
   metadata: Object,
@@ -64,4 +65,92 @@ export async function mintAccountNft(wasm: tari_wallet_lib.InitOutput, request: 
 
   const result = await sendInstructionInternal(wasm, sendInstructionRequest);
   return { result }
+}
+
+
+export type TransferNftRequest = {
+  nft_address: string,
+  nft_resource: string,
+  nft_id: string,
+  destination_public_key: string,
+  fee: number,
+};
+
+export async function transferNft(wasm: tari_wallet_lib.InitOutput, request: JsonRpcRequest<Json[] | Record<string, Json>>) {
+  const params = request.params as TransferNftRequest;
+  const { nft_address, nft_resource, nft_id, destination_public_key, fee } = params;
+
+  const accountIndex = 0;
+  const { public_key } = await getRistrettoKeyPair(accountIndex);
+  const account_component_address = tari_wallet_lib.get_account_component_address(public_key);
+
+  let instructions = [];
+
+  // create the recipient account if it does not exist already
+  const indexer_url = process.env.TARI_INDEXER_URL;
+  const destination_account_address = tari_wallet_lib.get_account_component_address(destination_public_key);
+  const destination_account_exists = await substateExists(indexer_url, destination_account_address);
+  if (!destination_account_exists) {
+    const owner_token = await tari_wallet_lib.get_owner_token(destination_public_key);
+    instructions.push({
+      CallFunction: {
+        template_address: ACCOUNT_TEMPLATE,
+        function: "create",
+        args: [{ "Literal": owner_token }]
+      }
+    });
+  }
+
+  // include the input substates of the transaction
+  let required_substates = [
+      { address: account_component_address, version: null },
+      { address: nft_address, version: null }
+  ];
+  if (destination_account_exists) {
+    required_substates.push({ address: destination_account_address, version: null });
+  }
+
+  // encode the NFT address parts to be passed as template arguments
+  const parsed_nft_resource = await tari_wallet_lib.parse_resource_address(nft_resource);
+  const encoded_nft_id = await tari_wallet_lib.encode_non_fungible_id(nft_id);
+
+  // build and send the mint transaction
+  // TODO: the instruction type should accept strings as well
+  let key = [97, 95, 98, 117, 99, 107, 101, 116];
+  let sendTransactionRequest: SendTransactionRequest = {
+    instructions: [
+      ...instructions,
+      {
+        CallMethod: {
+          component_address: account_component_address,
+          method: "withdraw_non_fungible",
+          args: [parsed_nft_resource,  { "Literal": encoded_nft_id }]
+        }
+      },
+      {
+        PutLastInstructionOutputOnWorkspace: {
+            key
+        }
+      },
+      {
+        CallMethod: {
+            component_address: destination_account_address,
+            method: "deposit",
+            args: [{ "Workspace": key }]
+        }
+      },
+      {
+        CallMethod: {
+            component_address: account_component_address,
+            method: "pay_fee",
+            args: [`Amount(${fee})`]
+        }
+      }
+    ],
+    input_refs: [],
+    required_substates,
+    is_dry_run: false,
+  };
+
+  return await sendTransactionInternal(wasm, sendTransactionRequest);
 }

--- a/packages/snap/src/tari_indexer_client.ts
+++ b/packages/snap/src/tari_indexer_client.ts
@@ -30,13 +30,18 @@ export async function sendIndexerRequest(tari_indexer_url: string, method: strin
     return result;
 }
 
-export async function substateExists(tari_indexer_url: string, substate_address: string) {
-    const method = 'get_substate';
+export async function getSubstate(tari_indexer_url: string, substate_address: string) {
+    const method = 'inspect_substate';
     const params = {
         address: substate_address,
         version: null
     };
     const result = await rawIndexerCall(tari_indexer_url, method, params);
+    return result;
+}
+
+export async function substateExists(tari_indexer_url: string, substate_address: string) {
+    const result = await getSubstate(tari_indexer_url, substate_address);
 
     if (result && !result.error) {
         return true;

--- a/packages/snap/src/transactions.ts
+++ b/packages/snap/src/transactions.ts
@@ -1,0 +1,93 @@
+import { Json, JsonRpcRequest } from '@metamask/snaps-types';
+import { heading, panel, text } from '@metamask/snaps-ui';
+import * as tari_wallet_lib from './tari_wallet_lib';
+import { sendIndexerRequest } from './tari_indexer_client';
+import { getRistrettoKeyPair } from './keys';
+import { SendInstructionRequest, SendTransactionRequest } from './types';
+
+async function sendTransactionInternal(wasm: tari_wallet_lib.InitOutput, request: SendTransactionRequest) {
+    const { instructions, input_refs, required_substates, is_dry_run } = request;
+
+    const userConfirmation = await snap.request({
+        method: 'snap_dialog',
+        params: {
+            type: 'confirmation',
+            content: panel([
+                heading('New transaction'),
+                text(`This website requests a transaction from your account, do you want to proceed?.`),
+                text('**Instructions:** ' + JSON.stringify(instructions)),
+            ])
+        },
+    });
+    if (!userConfirmation) {
+        return;
+    }
+
+    const accountIndex = 0;
+    const { secret_key, public_key } = await getRistrettoKeyPair(accountIndex);
+
+    // build and sign transaction using the wasm lib
+    const transaction = tari_wallet_lib.create_transaction(secret_key, instructions, input_refs);
+
+    // send the transaction to the indexer
+    const indexer_url = process.env.TARI_INDEXER_URL;
+    const submit_method = 'submit_transaction';
+    let submit_params = {
+        transaction,
+        is_dry_run,
+        required_substates,
+    };
+
+    await sendIndexerRequest(indexer_url, submit_method, submit_params);
+
+    // TODO: keep polling the indexer until we get a result for the transaction
+    const transaction_id = transaction.id;
+
+    return { transaction_id };
+}
+
+export async function sendTransaction(wasm: tari_wallet_lib.InitOutput, request: JsonRpcRequest<Json[] | Record<string, Json>>) {
+    const params = request.params as SendTransactionRequest;
+    return await sendTransactionInternal(wasm, params);
+}
+
+export async function sendInstruction(wasm: tari_wallet_lib.InitOutput, request: JsonRpcRequest<Json[] | Record<string, Json>>) {
+    const params = request.params as SendInstructionRequest;
+    let { instructions, input_refs, required_substates, is_dry_run, fee, dump_account } = params;
+
+    if (dump_account) {
+        // TODO: the instruction type should accept strings as well
+        let key = [97, 95, 98, 117, 99, 107, 101, 116];
+
+        instructions.push({
+            PutLastInstructionOutputOnWorkspace: {
+                key
+            }
+        });
+        instructions.push({
+            CallMethod: {
+                component_address: dump_account,
+                method: "deposit",
+                args: [{ "Workspace": key }]
+            }
+        });
+    }
+
+    // automatically add fee payment instruction at the end
+    instructions.push({
+        CallMethod: {
+            component_address: dump_account,
+            method: "pay_fee",
+            args: [fee]
+        }
+    });
+
+    const sendTransactionRequest: SendTransactionRequest = {
+        instructions,
+        input_refs,
+        required_substates,
+        is_dry_run
+    };
+
+    return await sendTransactionInternal(wasm, sendTransactionRequest);
+}

--- a/packages/snap/src/transactions.ts
+++ b/packages/snap/src/transactions.ts
@@ -38,8 +38,6 @@ export async function sendTransactionInternal(wasm: tari_wallet_lib.InitOutput, 
         required_substates,
     };
 
-    //return JSON.stringify({ indexer_url, submit_method, submit_params });
-
     await sendIndexerRequest(indexer_url, submit_method, submit_params);
 
     // TODO: keep polling the indexer until we get a result for the transaction

--- a/packages/snap/src/transactions.ts
+++ b/packages/snap/src/transactions.ts
@@ -5,7 +5,7 @@ import { sendIndexerRequest } from './tari_indexer_client';
 import { getRistrettoKeyPair } from './keys';
 import { SendInstructionRequest, SendTransactionRequest } from './types';
 
-async function sendTransactionInternal(wasm: tari_wallet_lib.InitOutput, request: SendTransactionRequest) {
+export async function sendTransactionInternal(wasm: tari_wallet_lib.InitOutput, request: SendTransactionRequest) {
     const { instructions, input_refs, required_substates, is_dry_run } = request;
 
     const userConfirmation = await snap.request({
@@ -24,7 +24,7 @@ async function sendTransactionInternal(wasm: tari_wallet_lib.InitOutput, request
     }
 
     const accountIndex = 0;
-    const { secret_key, public_key } = await getRistrettoKeyPair(accountIndex);
+    const { secret_key } = await getRistrettoKeyPair(accountIndex);
 
     // build and sign transaction using the wasm lib
     const transaction = tari_wallet_lib.create_transaction(secret_key, instructions, input_refs);
@@ -37,6 +37,8 @@ async function sendTransactionInternal(wasm: tari_wallet_lib.InitOutput, request
         is_dry_run,
         required_substates,
     };
+
+    //return JSON.stringify({ indexer_url, submit_method, submit_params });
 
     await sendIndexerRequest(indexer_url, submit_method, submit_params);
 
@@ -51,9 +53,8 @@ export async function sendTransaction(wasm: tari_wallet_lib.InitOutput, request:
     return await sendTransactionInternal(wasm, params);
 }
 
-export async function sendInstruction(wasm: tari_wallet_lib.InitOutput, request: JsonRpcRequest<Json[] | Record<string, Json>>) {
-    const params = request.params as SendInstructionRequest;
-    let { instructions, input_refs, required_substates, is_dry_run, fee, dump_account } = params;
+export async function sendInstructionInternal(wasm: tari_wallet_lib.InitOutput, request: SendInstructionRequest) {
+    let { instructions, input_refs, required_substates, is_dry_run, fee, dump_account } = request;
 
     if (dump_account) {
         // TODO: the instruction type should accept strings as well
@@ -78,7 +79,7 @@ export async function sendInstruction(wasm: tari_wallet_lib.InitOutput, request:
         CallMethod: {
             component_address: dump_account,
             method: "pay_fee",
-            args: [fee]
+            args: [`Amount(${fee})`]
         }
     });
 
@@ -90,4 +91,9 @@ export async function sendInstruction(wasm: tari_wallet_lib.InitOutput, request:
     };
 
     return await sendTransactionInternal(wasm, sendTransactionRequest);
+}
+
+export async function sendInstruction(wasm: tari_wallet_lib.InitOutput, request: JsonRpcRequest<Json[] | Record<string, Json>>) {
+    const params = request.params as SendInstructionRequest;
+    return await sendInstructionInternal(wasm, params);
 }

--- a/packages/snap/src/types.ts
+++ b/packages/snap/src/types.ts
@@ -16,3 +16,12 @@ export type SendTransactionRequest = {
     required_substates: Object[],
     is_dry_run: boolean, 
 };
+
+export type SendInstructionRequest = {
+    instructions: Object[],
+    input_refs: Object[],
+    required_substates: Object[],
+    is_dry_run: boolean,
+    fee: number,
+    dump_account: string,
+};

--- a/packages/snap/src/types.ts
+++ b/packages/snap/src/types.ts
@@ -25,3 +25,7 @@ export type SendInstructionRequest = {
     fee: number,
     dump_account: string,
 };
+
+export type GetSubstateRequest = {
+    substate_address: string,
+};

--- a/tari_wallet_lib/Cargo.lock
+++ b/tari_wallet_lib/Cargo.lock
@@ -811,6 +811,7 @@ dependencies = [
  "serde-wasm-bindgen",
  "serde_json",
  "tari_crypto",
+ "tari_template_abi",
  "tari_template_lib",
  "thiserror",
  "wasm-bindgen",

--- a/tari_wallet_lib/Cargo.toml
+++ b/tari_wallet_lib/Cargo.toml
@@ -22,6 +22,7 @@ console_error_panic_hook = "0.1"
 tari_crypto = { version = "0.17" }
 thiserror = "1.0.49"
 tari_template_lib = { git="https://github.com/tari-project/tari-dan.git" }
+tari_template_abi = { git="https://github.com/tari-project/tari-dan.git" }
 digest = "0.9.0"
 serde = "1.0.126"
 serde_json = "1.0"

--- a/tari_wallet_lib/src/component.rs
+++ b/tari_wallet_lib/src/component.rs
@@ -12,6 +12,16 @@ pub fn get_account_address_from_public_key(public_key: &str) -> Result<Component
     Ok(account_address)
 }
 
+pub fn get_account_nft_address_from_public_key(public_key: &str) -> Result<ComponentAddress, JsError> {
+    let destination_component_id = Hash::from_hex(public_key)?;
+    const ACCOUNT_NFT_TEMPLATE_ADDRESS: TemplateAddress = TemplateAddress::from_array([
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+    ]);
+    let account_nft_address = new_component_address_from_parts(&ACCOUNT_NFT_TEMPLATE_ADDRESS, &destination_component_id);
+
+    Ok(account_nft_address)
+}
+
 pub fn new_component_address_from_parts(template_address: &TemplateAddress, component_id: &Hash) -> ComponentAddress {
     let address = hasher(EngineHashDomainLabel::ComponentAddress)
         .chain(template_address)

--- a/tari_wallet_lib/src/lib.rs
+++ b/tari_wallet_lib/src/lib.rs
@@ -21,7 +21,7 @@ use tari_crypto::tari_utilities::hex::Hex;
 use tari_crypto::tari_utilities::ByteArray;
 use tari_template_lib::args;
 use tari_template_lib::prelude::{
-    Amount, NonFungibleAddress, ResourceAddress, RistrettoPublicKeyBytes, TemplateAddress, tari_bor,
+    Amount, NonFungibleAddress, ResourceAddress, RistrettoPublicKeyBytes, TemplateAddress, tari_bor, NonFungibleId,
 };
 use transaction::instruction::Instruction;
 use transaction::transaction::Transaction;
@@ -66,6 +66,20 @@ pub fn get_owner_token(public_key_hex: &str) -> Result<JsValue, JsError> {
 #[wasm_bindgen]
 pub fn encode_metadata(metadata_js: JsValue) -> Result<JsValue, JsError> {
     metadata::encode_metadata(metadata_js)
+}
+
+#[wasm_bindgen]
+pub fn parse_resource_address(resource_address_str: &str) -> Result<JsValue, JsError> {
+    let resource_address =  ResourceAddress::from_str(resource_address_str)?;
+    Ok(serde_wasm_bindgen::to_value(&resource_address)?)
+}
+
+#[wasm_bindgen]
+pub fn encode_non_fungible_id(id_str: &str) -> Result<JsValue, JsError> {
+    let id =  NonFungibleId::try_from_canonical_string(id_str)
+        .map_err(|_| JsError::new("Invalid NonFungibleId String"))?;
+    let encoded_id = tari_bor::encode(&id)?;
+    Ok(serde_wasm_bindgen::to_value(&encoded_id)?)
 }
 
 #[wasm_bindgen]

--- a/tari_wallet_lib/src/lib.rs
+++ b/tari_wallet_lib/src/lib.rs
@@ -2,6 +2,7 @@ pub mod argument_parser;
 pub mod component;
 pub mod fee_claim;
 pub mod hashing;
+pub mod metadata;
 pub mod serde_with;
 pub mod shard_id;
 pub mod substate;
@@ -11,7 +12,7 @@ pub mod types;
 
 use std::str::FromStr;
 
-use component::get_account_address_from_public_key;
+use component::{get_account_address_from_public_key, get_account_nft_address_from_public_key};
 use shard_id::ShardId;
 use substate::SubstateAddress;
 use tari_crypto::keys::PublicKey;
@@ -20,7 +21,7 @@ use tari_crypto::tari_utilities::hex::Hex;
 use tari_crypto::tari_utilities::ByteArray;
 use tari_template_lib::args;
 use tari_template_lib::prelude::{
-    Amount, NonFungibleAddress, ResourceAddress, RistrettoPublicKeyBytes, TemplateAddress,
+    Amount, NonFungibleAddress, ResourceAddress, RistrettoPublicKeyBytes, TemplateAddress, tari_bor,
 };
 use transaction::instruction::Instruction;
 use transaction::transaction::Transaction;
@@ -43,6 +44,28 @@ pub fn build_ristretto_public_key(ecdsa_private_key: &str) -> Result<String, JsE
 pub fn get_account_component_address(public_key: &str) -> Result<String, JsError> {
     let account_address = get_account_address_from_public_key(&public_key)?;
     Ok(account_address.to_string())
+}
+
+#[wasm_bindgen]
+pub fn get_account_nft_component_address(public_key: &str) -> Result<String, JsError> {
+    let account_nft_address = get_account_nft_address_from_public_key(&public_key)?;
+    Ok(account_nft_address.to_string())
+}
+
+#[wasm_bindgen]
+pub fn get_owner_token(public_key_hex: &str) -> Result<JsValue, JsError> {
+    let public_key = RistrettoPublicKey::from_hex(public_key_hex)?;
+    let owner_token = NonFungibleAddress::from_public_key(
+        RistrettoPublicKeyBytes::from_bytes(public_key.as_bytes()).unwrap(),
+    );
+    let encoded_token = tari_bor::encode(&owner_token)?;
+    
+    Ok(serde_wasm_bindgen::to_value(&encoded_token)?)
+}
+
+#[wasm_bindgen]
+pub fn encode_metadata(metadata_js: JsValue) -> Result<JsValue, JsError> {
+    metadata::encode_metadata(metadata_js)
 }
 
 #[wasm_bindgen]

--- a/tari_wallet_lib/src/metadata.rs
+++ b/tari_wallet_lib/src/metadata.rs
@@ -1,0 +1,20 @@
+use serde::{Serialize, Deserialize};
+use tari_template_lib::prelude::{Metadata, tari_bor};
+use wasm_bindgen::{JsValue, JsError};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MetadataField {
+    key: String,
+    value: String,
+}
+
+pub fn encode_metadata(metadata_js: JsValue) -> Result<JsValue, JsError> {
+    let fields: Vec<MetadataField> = serde_wasm_bindgen::from_value(metadata_js)?;
+    let mut metadata = Metadata::new();
+    for field in fields {
+        metadata.insert(field.key, field.value);
+    }
+    let encoded_metadata = tari_bor::encode(&metadata)?;
+    
+    Ok(serde_wasm_bindgen::to_value(&encoded_metadata)?)
+}


### PR DESCRIPTION
This PR adds a new tab `NFTs` in the Tari Wallet:
* Displays a **gallery of owned NFTs**, by inspecting the account component of the user and decoding the `metadata` of the `NonFungible` resources owned.
* Allows to **mint a new NFT**, specifying a image URL and a name, which will be set as the `metadata` of the Tari `NonFungible` resource.
* Allows to **send NFTs** to other accounts

<img width="710" alt="Screenshot 2023-11-02 at 11 41 29" src="https://github.com/tari-project/tari-snap/assets/47919901/f47a8022-837b-42b2-b376-8357c8eb9d9a">

<img width="710" alt="Screenshot 2023-11-02 at 11 43 46" src="https://github.com/tari-project/tari-snap/assets/47919901/628ec88a-efad-4e05-a337-63272b74e2b7">

<img width="710" alt="Screenshot 2023-11-02 at 11 44 26" src="https://github.com/tari-project/tari-snap/assets/47919901/4d205a66-e4a6-4f76-8608-40e428373213">



