### PR TITLE
fix: incorrect nft section import capitalization

### DIFF
--- a/packages/site/src/pages/index.tsx
+++ b/packages/site/src/pages/index.tsx
@@ -4,7 +4,7 @@ import Transactions from '../components/sections/Transactions';
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import MenuItem from '@mui/material/MenuItem';
-import Nfts from '../components/sections/NFTs';
+import Nfts from '../components/sections/Nfts';
 
 
 function Index() {


### PR DESCRIPTION
Fixed wrong capitalization of the Nft component path
It does not fail in local development, only when building the project and serving from the "public" folder