### PR TITLE
fix: correct transaction fees for testnet

### DIFF
--- a/packages/site/src/components/SendDialog.tsx
+++ b/packages/site/src/components/SendDialog.tsx
@@ -31,6 +31,7 @@ export function SendDialog(props: SendDialogProps) {
     const [tokenBalance, setTokenBalance] = React.useState(0);
     const [amount, setAmount] = React.useState(0);
     const [recipient, setRecipient] = React.useState('');
+    const [fee, setFee] = React.useState(0);
 
     // clear dialog form each time it closes
     useEffect(() => {
@@ -74,6 +75,10 @@ export function SendDialog(props: SendDialogProps) {
         setRecipient(event.target.value);
     };
 
+    const handleFeeChange = async (event) => {
+        setFee(event.target.value);
+    };
+
     const handleMaxBalanceClick = async () => {
         setAmount(tokenBalance);
     };
@@ -101,7 +106,7 @@ export function SendDialog(props: SendDialogProps) {
                             amount,
                             resource_address: token,
                             destination_public_key: recipient,
-                            fee: 1,
+                            fee,
                         }
                     }
                 },
@@ -174,6 +179,15 @@ export function SendDialog(props: SendDialogProps) {
                     </Typography>
                     <TextField sx={{ mt: 1, width: '100%' }} id="recipient" placeholder="0"
                         onChange={handleRecipientChange}
+                        InputProps={{
+                            sx: { borderRadius: 4 },
+                        }}>
+                    </TextField>
+                    <Typography sx={{ mt: 4 }} style={{ fontSize: 14 }}>
+                        Fee
+                    </Typography>
+                    <TextField sx={{ mt: 1, width: '100%' }} id="fee" placeholder="0"
+                        onChange={handleFeeChange}
                         InputProps={{
                             sx: { borderRadius: 4 },
                         }}>

--- a/packages/site/src/components/sections/Balances.tsx
+++ b/packages/site/src/components/sections/Balances.tsx
@@ -99,7 +99,7 @@ function Balances() {
     };
 
     const handleGetTestCoinsClick = async () => {
-        await getFreeTestCoins(1000, 1);
+        await getFreeTestCoins(100000, 1000);
     };
 
     return (

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/template-snap-monorepo.git"
   },
   "source": {
-    "shasum": "g8CvVnQG4aMwa6l6oYe7mzmEIM74X+77z8Jn1ofEfgY=",
+    "shasum": "ArjqcUGO96p8qS7+dku5oRbk1SyqQPim1aSw1EZWH4o=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/index.ts
+++ b/packages/snap/src/index.ts
@@ -164,12 +164,11 @@ async function transfer(request: JsonRpcRequest<Json[] | Record<string, Json>>) 
     );
   }
 
-  await sendIndexerRequest(indexer_url, submit_method, submit_params);
+  const res = await sendIndexerRequest(indexer_url, submit_method, submit_params);
 
   // TODO: keep polling the indexer until we get a result for the transaction
-  const transaction_id = transaction.id;
 
-  return { transaction_id };
+  return res;
 }
 
 async function getTransactions(request: JsonRpcRequest<Json[] | Record<string, Json>>) {

--- a/packages/snap/src/transactions.ts
+++ b/packages/snap/src/transactions.ts
@@ -38,12 +38,11 @@ export async function sendTransactionInternal(wasm: tari_wallet_lib.InitOutput, 
         required_substates,
     };
 
-    await sendIndexerRequest(indexer_url, submit_method, submit_params);
+    const res = await sendIndexerRequest(indexer_url, submit_method, submit_params);
 
     // TODO: keep polling the indexer until we get a result for the transaction
-    const transaction_id = transaction.id;
 
-    return { transaction_id };
+    return res;
 }
 
 export async function sendTransaction(wasm: tari_wallet_lib.InitOutput, request: JsonRpcRequest<Json[] | Record<string, Json>>) {


### PR DESCRIPTION
The snap wallet transactions do not work on testnet. This is due to very low hardcoded fees set up in the wallet. This PR fixes it by following the same behaviour as the wallet daemon UI:
* Allowing the user to specify the fee to pay on transfers
* Setting up a higher value for claiming testnet coins

This PR was tested on a local indexer connected to the real testnet.