### PR TITLE
feat: badge support

### DIFF
--- a/packages/site/gatsby-browser.tsx
+++ b/packages/site/gatsby-browser.tsx
@@ -1,14 +1,11 @@
 import { GatsbyBrowser } from 'gatsby';
-import { StrictMode } from 'react';
 import { App } from './src/App';
 import { Root } from './src/Root';
 
 export const wrapRootElement: GatsbyBrowser['wrapRootElement'] = ({
   element,
 }) => (
-  <StrictMode>
     <Root>{element}</Root>
-  </StrictMode>
 );
 
 export const wrapPageElement: GatsbyBrowser['wrapPageElement'] = ({

--- a/packages/site/gatsby-ssr.tsx
+++ b/packages/site/gatsby-ssr.tsx
@@ -1,12 +1,9 @@
 import { GatsbySSR } from 'gatsby';
-import { StrictMode } from 'react';
 import { App } from './src/App';
 import { Root } from './src/Root';
 
 export const wrapRootElement: GatsbySSR['wrapRootElement'] = ({ element }) => (
-  <StrictMode>
     <Root>{element}</Root>
-  </StrictMode>
 );
 
 export const wrapPageElement: GatsbySSR['wrapPageElement'] = ({ element }) => (

--- a/packages/site/src/components/MintDialog.tsx
+++ b/packages/site/src/components/MintDialog.tsx
@@ -20,6 +20,7 @@ export function MintDialog(props: MintDialogProps) {
 
     const [url, setUrl] = React.useState('');
     const [name, setName] = React.useState('');
+    const [fee, setFee] = React.useState(0);
 
     // clear dialog form each time it closes
     useEffect(() => {
@@ -41,12 +42,19 @@ export function MintDialog(props: MintDialogProps) {
         setName(event.target.value);
     };
 
+    const handleFeeChange = async (event) => {
+        setFee(event.target.value);
+    };
+
     const handleMintClick = async () => {
         try {
-            const metadata = [
-                { key: 'name', value: name },
-                { key: 'image_url', value: url },
-            ];
+            const metadata = [];
+            if (name) {
+                metadata.push({ key: 'name', value: name });
+            }
+            if (url) {
+                metadata.push({ key: 'image_url', value: url });
+            }
             const response = await window.ethereum.request({
                 method: 'wallet_invokeSnap',
                 params: {
@@ -55,7 +63,7 @@ export function MintDialog(props: MintDialogProps) {
                         method: 'mintAccountNft',
                         params: {
                             metadata,
-                            fee: 1,
+                            fee,
                         }
                     }
                 },
@@ -102,6 +110,18 @@ export function MintDialog(props: MintDialogProps) {
                     InputProps={{
                         sx: { borderRadius: 4, mt: 1 },
                     }}></TextField>
+                <Typography sx={{ mt: 3 }} style={{ fontSize: 14 }}>
+                    Fee
+                </Typography>
+                <TextField sx={{ mt: 1, width: '100%' }} 
+                    placeholder="0"
+                    id="input-fee"
+                    value={fee}
+                    onChange={handleFeeChange}
+                    InputProps={{
+                        sx: { borderRadius: 4, mt: 1 },
+                    }}>
+                 </TextField>
                 <Stack direction="row" justifyContent="center" sx={{ mt: 3, width: '100%' }}>
                     <ThemeFullWidthButton text="Mint" onClick={handleMintClick} />
                 </Stack>

--- a/packages/site/src/components/SendNftDialog.tsx
+++ b/packages/site/src/components/SendNftDialog.tsx
@@ -12,6 +12,7 @@ import { MetaMaskContext, MetamaskActions, TariContext } from "../hooks";
 import { ThemeFullWidthButton } from "./Buttons";
 import { copyToCliboard, truncateText } from "../utils/text";
 import { defaultSnapOrigin } from "../config/snap";
+import BadgeOutlined from '@mui/icons-material/BadgeOutlined';
 
 export interface SendNftDialogProps {
     nft: Object | null;
@@ -90,7 +91,9 @@ export function SendNftDialog(props: SendNftDialogProps) {
                 </Stack>
                 <Divider sx={{ mt: 3, mb: 3 }} variant="middle" />
                 <Box sx={{ textAlign: 'center' }}>
-                    <img style={{ maxWidth: '50%', maxHeight: '50%', borderRadius: '10px' }} src={nft.metadata.image_url} />
+                    {nft.metadata.image_url ?
+                        (<img style={{ maxWidth: '50%', maxHeight: '50%', borderRadius: '10px' }} src={nft.metadata.image_url}/>):
+                        (<BadgeOutlined color='disabled' style={{ fontSize: 64, height: '100%' }}/>)}
                 </Box>
                 <Stack direction="column" alignItems="center" justifyContent="center" sx={{mt:2}}>
                     <Typography alignSelf="center" style={{ fontSize: 18 }} >

--- a/packages/site/src/components/SendNftDialog.tsx
+++ b/packages/site/src/components/SendNftDialog.tsx
@@ -13,6 +13,7 @@ import { ThemeFullWidthButton } from "./Buttons";
 import { copyToCliboard, truncateText } from "../utils/text";
 import { defaultSnapOrigin } from "../config/snap";
 import BadgeOutlined from '@mui/icons-material/BadgeOutlined';
+import QuestionMarkOutlined from "@mui/icons-material/QuestionMarkOutlined";
 
 export interface SendNftDialogProps {
     nft: Object | null;
@@ -37,6 +38,14 @@ export function SendNftDialog(props: SendNftDialogProps) {
     const handleRecipientChange = async (event) => {
         setRecipient(event.target.value);
     };
+
+    const nftIsImage = (nft: any) => {
+        return nft.metadata.image_url;
+    }
+
+    const nftIsBadge = (nft: any) => {
+        return Object.keys(nft.metadata).length === 0;
+    }
 
     const handleSendClick = async () => {
         try {
@@ -91,11 +100,13 @@ export function SendNftDialog(props: SendNftDialogProps) {
                 </Stack>
                 <Divider sx={{ mt: 3, mb: 3 }} variant="middle" />
                 <Box sx={{ textAlign: 'center' }}>
-                    {nft.metadata.image_url ?
-                        (<img style={{ maxWidth: '50%', maxHeight: '50%', borderRadius: '10px' }} src={nft.metadata.image_url}/>):
-                        (<BadgeOutlined color='disabled' style={{ fontSize: 64, height: '100%' }}/>)}
+                    {
+                        nftIsImage(nft) ? (<img style={{ maxWidth: '50%', maxHeight: '50%', borderRadius: '10px' }} src={nft.metadata.image_url} />) :
+                        nftIsBadge(nft) ? (<BadgeOutlined color='disabled' style={{ fontSize: 64, height: '100%' }} />) :
+                        (<QuestionMarkOutlined color='disabled' style={{ fontSize: 64, height: '100%' }} />)
+                    }
                 </Box>
-                <Stack direction="column" alignItems="center" justifyContent="center" sx={{mt:2}}>
+                <Stack direction="column" alignItems="center" justifyContent="center" sx={{ mt: 2 }}>
                     <Typography alignSelf="center" style={{ fontSize: 18 }} >
                         {truncateText(nft.metadata.name, 20)}
                     </Typography>

--- a/packages/site/src/components/sections/Nfts.tsx
+++ b/packages/site/src/components/sections/Nfts.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect } from 'react';
+import { useContext, useEffect, useRef } from 'react';
 import { MetaMaskContext, MetamaskActions, TariContext } from '../../hooks';
 import Container from '@mui/material/Container';
 import Typography from '@mui/material/Typography';
@@ -17,6 +17,7 @@ import { MintDialog } from '../MintDialog';
 import StartIcon from '@mui/icons-material/Start';
 import { SendNftDialog } from '../SendNftDialog';
 import BadgeOutlined from '@mui/icons-material/BadgeOutlined';
+import Checkbox from '@mui/material/Checkbox';
 
 function Nfts() {
     const [metamaskState, metamaskDispatch] = useContext(MetaMaskContext);
@@ -27,6 +28,10 @@ function Nfts() {
     const [selectedNft, setSelectedNft] = React.useState(null);
     const [sendDialogOpen, setSendDialogOpen] = React.useState(false);
     const [nfts, setNfts] = React.useState([]);
+    const [filteredNfts, setFilteredNfts] = React.useState([]);
+    const [imageNftCheck, setImageNftCheck] = React.useState(true);
+    const [badgeNftCheck, setBadgeNftCheck] = React.useState(true);
+    const [otherNftCheck, setOtherNftCheck] = React.useState(true);
 
     const getNfts = async () => {
         try {
@@ -86,6 +91,48 @@ function Nfts() {
     useEffect(() => {
         refreshNfts();
     }, []);
+
+    const nftIsImage = (nft: any) => {
+        return nft.metadata.image_url;
+    }
+
+    const nftIsBadge = (nft: any) => {
+        return Object.keys(nft.metadata).length === 0;
+    }
+
+    // filter grid of nfts when the checkboxes or the account nfts change
+    useEffect(() => {
+        let filtered = nfts;
+
+        if (!imageNftCheck) {
+            filtered = filtered.filter((nft) => !nftIsImage(nft));
+        }
+
+        if (!badgeNftCheck) {
+            filtered = filtered.filter((nft) => !nftIsBadge(nft));
+        }
+
+        if (!otherNftCheck) {
+            filtered = filtered.filter((nft) => !nftIsImage(nft) || !nftIsBadge(nft));
+        }
+
+        setFilteredNfts(filtered);
+    }, [nfts, imageNftCheck, badgeNftCheck, otherNftCheck]);
+
+    const handleCheckImages = (event: any) => {
+        let checkboxValue = event.target.checked;
+        setImageNftCheck(checkboxValue);
+    };
+
+    const handleCheckBadges = (event: any) => {
+        let checkboxValue = event.target.checked;
+        setBadgeNftCheck(checkboxValue);
+    };
+
+    const handleCheckOther = (event: any) => {
+        let checkboxValue = event.target.checked;
+        setOtherNftCheck(checkboxValue);
+    };
 
     const handleMintOpen = () => {
         setMintDialogOpen(true);
@@ -147,28 +194,42 @@ function Nfts() {
                             <Typography style={{ fontSize: 24 }} >
                                 Owned NFTs
                             </Typography>
-                        </Stack>
-                        <Grid container spacing={2} sx={{ mt: 3}}>
-                            {nfts.map((nft: any) => (
-                                <Grid item xs={3}>
-                                    <Stack direction="column" sx={{padding: 1, height: '100%' }}>
-                                        <Box sx={{ textAlign: 'center', verticalAlign: 'middle', height: '80%'}}>
-                                            {nft.metadata.image_url ?
-                                                (<img style={{borderRadius: 8, width: '100%'}} src={nft.metadata.image_url}/>):
-                                                (<BadgeOutlined color='disabled' style={{ fontSize: 64, height: '100%' }}/>)}
-                                        </Box>
-                                        <Stack direction="row" spacing={2} sx={{mt: 0.5}}>
-                                            <Typography style={{ fontSize: 16 }} >
-                                                {nft.metadata.name ? truncateText(nft.metadata.name, 20) : truncateText(nft.address, 20)}
-                                            </Typography>
-                                            <IconButton aria-label="send" sx={{padding:0, minHeight: 0}} onClick={() => handleSendOpen(nft)}>
-                                                <StartIcon style={{ fontSize: 16 }}/>
-                                            </IconButton>
+                            <Stack direction="row" spacing={2} sx={{ mt: 0.5 }}>
+                                <Stack direction="row" spacing={0.5} justifyContent="flex-start" alignItems='center'>
+                                    <Checkbox defaultChecked onClick={handleCheckImages} value={imageNftCheck} />
+                                    <Typography style={{ fontSize: 14 }}>Images</Typography>
+                                </Stack>
+                                <Stack direction="row" spacing={0.5} justifyContent="flex-start" alignItems='center'>
+                                    <Checkbox defaultChecked onClick={handleCheckBadges} value={badgeNftCheck} />
+                                    <Typography style={{ fontSize: 14 }}>Badges</Typography>
+                                </Stack>
+                                <Stack direction="row" spacing={0.5} justifyContent="flex-start" alignItems='center'>
+                                    <Checkbox defaultChecked onClick={handleCheckOther} value={otherNftCheck} />
+                                    <Typography style={{ fontSize: 14 }}>Other</Typography>
+                                </Stack>
+                            </Stack>
+                            <Grid container spacing={2} sx={{ mt: 3 }}>
+                                {filteredNfts.map((nft: any) => (
+                                    <Grid item xs={3}>
+                                        <Stack direction="column" sx={{ padding: 1, height: '100%' }}>
+                                            <Box sx={{ textAlign: 'center', verticalAlign: 'middle', height: '80%' }}>
+                                                {nft.metadata.image_url ?
+                                                    (<img style={{ borderRadius: 8, width: '100%' }} src={nft.metadata.image_url} />) :
+                                                    (<BadgeOutlined color='disabled' style={{ fontSize: 64, height: '100%' }} />)}
+                                            </Box>
+                                            <Stack direction="row" spacing={2} sx={{ mt: 0.5 }}>
+                                                <Typography style={{ fontSize: 16 }} >
+                                                    {nft.metadata.name ? truncateText(nft.metadata.name, 20) : truncateText(nft.address, 20)}
+                                                </Typography>
+                                                <IconButton aria-label="send" sx={{ padding: 0, minHeight: 0 }} onClick={() => handleSendOpen(nft)}>
+                                                    <StartIcon style={{ fontSize: 16 }} />
+                                                </IconButton>
+                                            </Stack>
                                         </Stack>
-                                    </Stack>
-                                </Grid>
-                            ))}
-                        </Grid>
+                                    </Grid>
+                                ))}
+                            </Grid>
+                        </Stack>
                     </Paper>
                     <MintDialog
                         open={mintDialogOpen}

--- a/packages/site/src/components/sections/Nfts.tsx
+++ b/packages/site/src/components/sections/Nfts.tsx
@@ -17,7 +17,9 @@ import { MintDialog } from '../MintDialog';
 import StartIcon from '@mui/icons-material/Start';
 import { SendNftDialog } from '../SendNftDialog';
 import BadgeOutlined from '@mui/icons-material/BadgeOutlined';
+import QuestionMarkOutlined from '@mui/icons-material/QuestionMarkOutlined';
 import Checkbox from '@mui/material/Checkbox';
+
 
 function Nfts() {
     const [metamaskState, metamaskDispatch] = useContext(MetaMaskContext);
@@ -113,7 +115,7 @@ function Nfts() {
         }
 
         if (!otherNftCheck) {
-            filtered = filtered.filter((nft) => !nftIsImage(nft) || !nftIsBadge(nft));
+            filtered = filtered.filter((nft) => nftIsImage(nft) || nftIsBadge(nft));
         }
 
         setFilteredNfts(filtered);
@@ -213,9 +215,11 @@ function Nfts() {
                                     <Grid item xs={3}>
                                         <Stack direction="column" sx={{ padding: 1, height: '100%' }}>
                                             <Box sx={{ textAlign: 'center', verticalAlign: 'middle', height: '80%' }}>
-                                                {nft.metadata.image_url ?
-                                                    (<img style={{ borderRadius: 8, width: '100%' }} src={nft.metadata.image_url} />) :
-                                                    (<BadgeOutlined color='disabled' style={{ fontSize: 64, height: '100%' }} />)}
+                                                {
+                                                    nftIsImage(nft) ? (<img style={{ borderRadius: 8, width: '100%' }} src={nft.metadata.image_url} />) :
+                                                    nftIsBadge(nft) ? (<BadgeOutlined color='disabled' style={{ fontSize: 64, height: '100%' }} />) :
+                                                    (<QuestionMarkOutlined color='disabled' style={{ fontSize: 64, height: '100%' }} />)
+                                                }
                                             </Box>
                                             <Stack direction="row" spacing={2} sx={{ mt: 0.5 }}>
                                                 <Typography style={{ fontSize: 16 }} >

--- a/packages/site/src/components/sections/Nfts.tsx
+++ b/packages/site/src/components/sections/Nfts.tsx
@@ -7,21 +7,16 @@ import Stack from '@mui/material/Stack';
 import React from 'react';
 import Box from '@mui/material/Box';
 import { ThemeButton } from '../Buttons';
-import { defaultSnapOrigin } from '../../config/snap';
 import { ReceiveDialog } from '../ReceiveDialog';
 import IconButton from '@mui/material/IconButton';
-import { copyToCliboard } from '../../utils/text';
+import { copyToCliboard, truncateText } from '../../utils/text';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import { getAccountData, getSubstate } from '../../utils/snap';
 import Grid from '@mui/material/Grid';
-import ImageList from '@mui/material/ImageList';
-import ImageListItem from '@mui/material/ImageListItem';
-import ImageListItemBar from '@mui/material/ImageListItemBar';
 import { MintDialog } from '../MintDialog';
-import { styled } from '@mui/material/styles';
-import Card from '@mui/material/Card';
 import StartIcon from '@mui/icons-material/Start';
 import { SendNftDialog } from '../SendNftDialog';
+import BadgeOutlined from '@mui/icons-material/BadgeOutlined';
 
 function Nfts() {
     const [metamaskState, metamaskDispatch] = useContext(MetaMaskContext);
@@ -154,15 +149,17 @@ function Nfts() {
                             </Typography>
                         </Stack>
                         <Grid container spacing={2} sx={{ mt: 3}}>
-                            {nfts.map((nft) => (
+                            {nfts.map((nft: any) => (
                                 <Grid item xs={3}>
-                                    <Stack direction="column" sx={{padding: 1}}>
-                                        <Box sx={{ textAlign: 'center'}}>
-                                            <img style={{borderRadius: 8, width: '100%'}} src={nft.metadata.image_url}/>
+                                    <Stack direction="column" sx={{padding: 1, height: '100%' }}>
+                                        <Box sx={{ textAlign: 'center', verticalAlign: 'middle', height: '80%'}}>
+                                            {nft.metadata.image_url ?
+                                                (<img style={{borderRadius: 8, width: '100%'}} src={nft.metadata.image_url}/>):
+                                                (<BadgeOutlined color='disabled' style={{ fontSize: 64, height: '100%' }}/>)}
                                         </Box>
                                         <Stack direction="row" spacing={2} sx={{mt: 0.5}}>
                                             <Typography style={{ fontSize: 16 }} >
-                                                {nft.metadata.name}
+                                                {nft.metadata.name ? truncateText(nft.metadata.name, 20) : truncateText(nft.address, 20)}
                                             </Typography>
                                             <IconButton aria-label="send" sx={{padding:0, minHeight: 0}} onClick={() => handleSendOpen(nft)}>
                                                 <StartIcon style={{ fontSize: 16 }}/>

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/template-snap-monorepo.git"
   },
   "source": {
-    "shasum": "ArjqcUGO96p8qS7+dku5oRbk1SyqQPim1aSw1EZWH4o=",
+    "shasum": "ZJFM51UaNwVn7eKVjteUUJd+rzDyF0KfN6oWV7AdbGM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/tari_wallet_lib/Cargo.lock
+++ b/tari_wallet_lib/Cargo.lock
@@ -54,9 +54,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.4"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
+checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
 
 [[package]]
 name = "bincode"
@@ -75,9 +75,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
 name = "blake2"
@@ -114,9 +114,9 @@ checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cbindgen"
@@ -135,15 +135,6 @@ dependencies = [
  "syn 1.0.109",
  "tempfile",
  "toml",
-]
-
-[[package]]
-name = "cc"
-version = "1.0.83"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -209,9 +200,9 @@ checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.9"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
+checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
 dependencies = [
  "libc",
 ]
@@ -261,23 +252,12 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.4"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add4f07d43996f76ef320709726a556a9d4f965d9410d8d0271132d2f8293480"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
- "errno-dragonfly",
  "libc",
- "windows-sys",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -357,9 +337,9 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "js-sys"
-version = "0.3.64"
+version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
+checksum = "cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -381,15 +361,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.148"
+version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
+checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.8"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3852614a3bd9ca9804678ba6be5e3b8ce76dfc902cae004e3e0c44051b6e88db"
+checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
 
 [[package]]
 name = "log"
@@ -435,9 +415,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.67"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
+checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -510,9 +490,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.3.5"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
 ]
@@ -528,15 +508,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.15"
+version = "0.38.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f9da0cbd88f9f09e7814e388301c8414c51c62aa6ce1e4b5c551d49d96e531"
+checksum = "9470c4bf8246c8daf25f9598dca807fb6510347b1e1cfa55749113850c79d88a"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -553,33 +533,33 @@ checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "semver"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad977052201c6de01a8ef2aa3378c4bd23217a056337d1d6da40468d267a4fb0"
+checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 
 [[package]]
 name = "serde"
-version = "1.0.188"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
-name = "serde-big-array"
-version = "0.5.1"
+name = "serde-byte-array"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
+checksum = "63213ee4ed648dbd87db6fa993d4275b46bfb4ddfd95b3756045007c2b28f742"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde-wasm-bindgen"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30c9933e5689bd420dc6c87b7a1835701810cbc10cd86a26e4da45b73e6b1d78"
+checksum = "17ba92964781421b6cef36bf0d7da26d201e96d84e1b10e7ae6ed416e516906d"
 dependencies = [
  "js-sys",
  "serde",
@@ -588,20 +568,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.188"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.39",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.107"
+version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
+checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
 dependencies = [
  "itoa",
  "ryu",
@@ -645,9 +625,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.37"
+version = "2.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7303ef2c05cd654186cb250d29049a24840ca25d2747c25c0381c8d9e2f582e8"
+checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -670,8 +650,8 @@ dependencies = [
 
 [[package]]
 name = "tari_bor"
-version = "0.0.1"
-source = "git+https://github.com/tari-project/tari-dan.git#2b3b9ec78076151f65354a57ed99141ec929c173"
+version = "0.1.1"
+source = "git+https://github.com/tari-project/tari-dan.git#0f07b8161ce6493d76d549fc2fd1b8dd9d38dfd2"
 dependencies = [
  "ciborium",
  "ciborium-io",
@@ -751,8 +731,8 @@ dependencies = [
 
 [[package]]
 name = "tari_template_abi"
-version = "0.0.1"
-source = "git+https://github.com/tari-project/tari-dan.git#2b3b9ec78076151f65354a57ed99141ec929c173"
+version = "0.1.1"
+source = "git+https://github.com/tari-project/tari-dan.git#0f07b8161ce6493d76d549fc2fd1b8dd9d38dfd2"
 dependencies = [
  "serde",
  "tari_bor",
@@ -760,12 +740,12 @@ dependencies = [
 
 [[package]]
 name = "tari_template_lib"
-version = "0.0.1"
-source = "git+https://github.com/tari-project/tari-dan.git#2b3b9ec78076151f65354a57ed99141ec929c173"
+version = "0.1.1"
+source = "git+https://github.com/tari-project/tari-dan.git#0f07b8161ce6493d76d549fc2fd1b8dd9d38dfd2"
 dependencies = [
  "newtype-ops",
  "serde",
- "serde-big-array",
+ "serde-byte-array",
  "tari_bor",
  "tari_template_abi",
  "tari_template_macros",
@@ -773,12 +753,14 @@ dependencies = [
 
 [[package]]
 name = "tari_template_macros"
-version = "0.0.1"
-source = "git+https://github.com/tari-project/tari-dan.git#2b3b9ec78076151f65354a57ed99141ec929c173"
+version = "0.1.1"
+source = "git+https://github.com/tari-project/tari-dan.git#0f07b8161ce6493d76d549fc2fd1b8dd9d38dfd2"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+ "tari_bor",
+ "tari_template_abi",
 ]
 
 [[package]]
@@ -803,13 +785,14 @@ dependencies = [
 name = "tari_wallet_lib"
 version = "0.1.0"
 dependencies = [
- "base64 0.21.4",
+ "base64 0.21.5",
  "console_error_panic_hook",
  "digest",
  "rand",
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
+ "tari_bor",
  "tari_crypto",
  "tari_template_abi",
  "tari_template_lib",
@@ -820,15 +803,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.8.0"
+version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
+checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
 dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall",
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -842,22 +825,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.49"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1177e8c6d7ede7afde3585fd2513e611227efd6481bd78d2e82ba1ce16557ed4"
+checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.49"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
+checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -913,9 +896,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.87"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
+checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -923,24 +906,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.87"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
+checksum = "1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.39",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.37"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
+checksum = "ac36a15a220124ac510204aec1c3e5db8a22ab06fd6706d881dc6149f8ed9a12"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -950,9 +933,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.87"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
+checksum = "0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -960,28 +943,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.87"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
+checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.39",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.87"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.37"
+version = "0.3.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e6e302a7ea94f83a6d09e78e7dc7d9ca7b186bc2829c24a22d0753efd680671"
+checksum = "2cf9242c0d27999b831eae4767b2a146feb0b27d332d553e605864acd2afd403"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",
@@ -993,19 +976,20 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.37"
+version = "0.3.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecb993dd8c836930ed130e020e77d9b2e65dd0fbab1b67c790b0f5d80b11a575"
+checksum = "794645f5408c9a039fd09f4d113cdfb2e7eba5ff1956b07bcf701cf4b394fe89"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn 2.0.39",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.64"
+version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
+checksum = "50c24a44ec86bb68fbecd1b3efed7e85ea5621b39b35ef2766b66cd984f8010f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1039,7 +1023,16 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -1048,13 +1041,28 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.0",
+ "windows_aarch64_msvc 0.52.0",
+ "windows_i686_gnu 0.52.0",
+ "windows_i686_msvc 0.52.0",
+ "windows_x86_64_gnu 0.52.0",
+ "windows_x86_64_gnullvm 0.52.0",
+ "windows_x86_64_msvc 0.52.0",
 ]
 
 [[package]]
@@ -1064,10 +1072,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1076,10 +1096,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1088,10 +1120,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1100,10 +1144,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
-name = "zeroize"
-version = "1.6.0"
+name = "windows_x86_64_msvc"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+
+[[package]]
+name = "zeroize"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
 dependencies = [
  "zeroize_derive",
 ]
@@ -1116,5 +1166,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.39",
 ]

--- a/tari_wallet_lib/Cargo.toml
+++ b/tari_wallet_lib/Cargo.toml
@@ -23,6 +23,7 @@ tari_crypto = { version = "0.17" }
 thiserror = "1.0.49"
 tari_template_lib = { git="https://github.com/tari-project/tari-dan.git" }
 tari_template_abi = { git="https://github.com/tari-project/tari-dan.git" }
+tari_bor = { git="https://github.com/tari-project/tari-dan.git" }
 digest = "0.9.0"
 serde = "1.0.126"
 serde_json = "1.0"

--- a/tari_wallet_lib/src/fee_claim.rs
+++ b/tari_wallet_lib/src/fee_claim.rs
@@ -2,10 +2,9 @@
 //    SPDX-License-Identifier: BSD-3-Clause
 
 use std::{fmt, fmt::Display};
-
-use serde::{Deserialize, Serialize};
 use tari_bor::BorTag;
-use tari_template_lib::{models::BinaryTag, prelude::tari_bor, Hash};
+use serde::{Deserialize, Serialize};
+use tari_template_lib::{models::BinaryTag, Hash};
 
 use crate::hashing::{hasher, EngineHashDomainLabel};
 

--- a/tari_wallet_lib/src/hashing.rs
+++ b/tari_wallet_lib/src/hashing.rs
@@ -4,7 +4,7 @@ use digest::Digest;
 use serde::Serialize;
 use tari_bor::encode_into;
 use tari_crypto::{hash::blake2::Blake256, hash_domain, hashing::DomainSeparation};
-use tari_template_lib::{Hash, prelude::tari_bor::{self}};
+use tari_template_lib::Hash;
 
 hash_domain!(TariEngineHashDomain, "com.tari.dan.engine", 0);
 

--- a/tari_wallet_lib/src/lib.rs
+++ b/tari_wallet_lib/src/lib.rs
@@ -21,7 +21,7 @@ use tari_crypto::tari_utilities::hex::Hex;
 use tari_crypto::tari_utilities::ByteArray;
 use tari_template_lib::args;
 use tari_template_lib::prelude::{
-    Amount, NonFungibleAddress, ResourceAddress, RistrettoPublicKeyBytes, TemplateAddress, tari_bor, NonFungibleId,
+    Amount, NonFungibleAddress, ResourceAddress, RistrettoPublicKeyBytes, TemplateAddress, NonFungibleId,
 };
 use transaction::instruction::Instruction;
 use transaction::transaction::Transaction;

--- a/tari_wallet_lib/src/metadata.rs
+++ b/tari_wallet_lib/src/metadata.rs
@@ -1,5 +1,5 @@
 use serde::{Serialize, Deserialize};
-use tari_template_lib::prelude::{Metadata, tari_bor};
+use tari_template_lib::prelude::Metadata;
 use wasm_bindgen::{JsValue, JsError};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/tari_wallet_lib/src/substate.rs
+++ b/tari_wallet_lib/src/substate.rs
@@ -1,15 +1,14 @@
 use crate::{serde_with, hashing::{EngineHashDomainLabel, hasher}, transaction::transaction_receipt::TransactionReceiptAddress, fee_claim::FeeClaimAddress};
 use serde::{Deserialize, Serialize};
+use tari_bor::{encode, BorError, decode_exact};
 use std::{
     fmt::{Display, Formatter},
     str::FromStr,
 };
 use tari_template_lib::{Hash, prelude::NonFungibleId};
 use tari_template_lib::{
-    encode,
     models::{NonFungibleIndexAddress, UnclaimedConfidentialOutputAddress, VaultId},
     prelude::{
-        tari_bor::{decode_exact, BorError},
         ComponentAddress, NonFungibleAddress, ResourceAddress,
     },
 };

--- a/tari_wallet_lib/src/transaction/instruction.rs
+++ b/tari_wallet_lib/src/transaction/instruction.rs
@@ -10,7 +10,7 @@ use tari_template_lib::{
 use crate::types::{PublicKey, ConfidentialClaim, ConfidentialOutput};
 use crate::serde_with;
 
-#[derive(Debug, Clone, Deserialize, Serialize, Eq, PartialEq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub enum Instruction {
     CallFunction {
         #[serde(with = "serde_with::hex")]

--- a/tari_wallet_lib/src/transaction/transaction_receipt.rs
+++ b/tari_wallet_lib/src/transaction/transaction_receipt.rs
@@ -8,7 +8,7 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 use tari_bor::BorTag;
-use tari_template_lib::{models::BinaryTag, Hash, HashParseError, prelude::tari_bor};
+use tari_template_lib::{models::BinaryTag, Hash, HashParseError };
 
 const TAG: u64 = BinaryTag::TransactionReceipt.as_u64();
 


### PR DESCRIPTION
* The list of NFTs now have:
    * Specific display to differentiate NFTs that are images, badges or other types
    * Filter by type
* Badges or other types or NFTs can be sent to other accounts
* Removed problematic `StrictMode` tag in the wallet site, that caused double rendering of React components
* Adapted the WASM library of the snap to the latest changes in the Tari API