### PR TITLE
fix: error throwing syntax error

### DIFF
--- a/packages/snap/src/index.ts
+++ b/packages/snap/src/index.ts
@@ -108,7 +108,7 @@ async function getAccountData(
         return { type: 'nonfungible', resource_address, token_ids };
       }
 
-      thrdow new Error(
+      throw new Error(
         `Unknown resource container type ${JSON.stringify(container)}`,
       );
     }),


### PR DESCRIPTION
There is a JS syntax error on the snap index