### PR TITLE
fix: broken snap functionalities

### DIFF
--- a/packages/site/src/components/sections/Nfts.tsx
+++ b/packages/site/src/components/sections/Nfts.tsx
@@ -48,11 +48,12 @@ function Nfts() {
                 .map(res => {
                     const collection = res.resource_address;
                     const items = res.token_ids.map(id => {
-                        const id_str = int_array_to_hex(id.U256);
+                        const id_hex = int_array_to_hex(id.U256);
+                        const id_str = `uuid:${id_hex}`;
                         return {
-                            address: `${collection} nft_uuid:${id_str}`,
+                            address: `${collection} nft_${id_str}`,
                             collection,
-                            id
+                            id: id_str
                         }
                     });
                     return items;

--- a/packages/site/src/components/sections/Nfts.tsx
+++ b/packages/site/src/components/sections/Nfts.tsx
@@ -11,7 +11,7 @@ import { ReceiveDialog } from '../ReceiveDialog';
 import IconButton from '@mui/material/IconButton';
 import { copyToCliboard, truncateText } from '../../utils/text';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
-import { getAccountData, getSubstate } from '../../utils/snap';
+import { getAccountData, getSubstate, int_array_to_hex } from '../../utils/snap';
 import Grid from '@mui/material/Grid';
 import { MintDialog } from '../MintDialog';
 import StartIcon from '@mui/icons-material/Start';
@@ -48,8 +48,9 @@ function Nfts() {
                 .map(res => {
                     const collection = res.resource_address;
                     const items = res.token_ids.map(id => {
+                        const id_str = int_array_to_hex(id.U256);
                         return {
-                            address: `${collection} nft_${id}`,
+                            address: `${collection} nft_uuid:${id_str}`,
                             collection,
                             id
                         }
@@ -67,10 +68,14 @@ function Nfts() {
             }));
 
             const substates = nft_contents
-                .filter(nft => nft.content.result)
+                .filter(nft => nft.content.substate)
                 .map(nft => {
-                    //const address = content.result.address;
-                    const metadata = nft.content.result.substate_contents.substate.NonFungible.data['@@TAGGED@@'][1];
+                    const metadata_map = nft.content.substate.substate.NonFungible.data.Tag[1].Map;
+                    let metadata = {};
+                    metadata_map.map((entry) => {
+                        metadata[entry[0].Text] = entry[1].Text;
+                    });
+
                     return { ...nft, metadata };
                 });
 

--- a/packages/site/src/utils/snap.ts
+++ b/packages/site/src/utils/snap.ts
@@ -125,3 +125,19 @@ export function hex_to_int_array(hex_string: string) {
   const int_array = tokens.map(t => parseInt(t, 16));
   return int_array;
 }
+
+export function int_array_to_hex(byteArray: any) {
+  if (Array.isArray(byteArray)) {
+    return Array.from(byteArray, function(byte) {
+      return ("0" + (byte & 0xff).toString(16)).slice(-2);
+    }).join("");
+  }
+  if (byteArray === undefined) {
+    return "undefined";
+  }
+  // object might be a tagged object
+  if (byteArray["@@TAGGED@@"] !== undefined) {
+    return int_array_to_hex(byteArray["@@TAGGED@@"][1]);
+  }
+  return "Unsupported type";
+}

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/tari-project/tari-snap.git"
   },
   "source": {
-    "shasum": "1s7sPHrkLl9zzYeOTxsRUzk6Qg2NXGOhD8yaMsBu1bc=",
+    "shasum": "AcFgus52xSvON4Qoc/hAHFMZqziKTkBZT+G23gC0S/g=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/tari-project/tari-snap.git"
   },
   "source": {
-    "shasum": "ANWkIjP9uHRh7P7WUDjZD7lOtH5rCFL0dbOZ4OzRQ6c=",
+    "shasum": "aronf0C0TMh+lN53NFrswrAUUfwKdagMe6DYu1bdMTU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/tari-project/tari-snap.git"
   },
   "source": {
-    "shasum": "P5kxsXL/F/b/LP6CuUTyW5XlnM0/ITLlvfVfTNus/Wc=",
+    "shasum": "ANWkIjP9uHRh7P7WUDjZD7lOtH5rCFL0dbOZ4OzRQ6c=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/tari-project/tari-snap.git"
   },
   "source": {
-    "shasum": "aronf0C0TMh+lN53NFrswrAUUfwKdagMe6DYu1bdMTU=",
+    "shasum": "1s7sPHrkLl9zzYeOTxsRUzk6Qg2NXGOhD8yaMsBu1bc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/tari-project/tari-snap.git"
   },
   "source": {
-    "shasum": "AcFgus52xSvON4Qoc/hAHFMZqziKTkBZT+G23gC0S/g=",
+    "shasum": "bSvhF9tZ+PLR9Z0StQ1GYl5gdG9oFFfc2h3NTGz6hw0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/index.ts
+++ b/packages/snap/src/index.ts
@@ -174,18 +174,18 @@ async function transfer(
     is_dry_run: false,
     required_substates: [
       {
-        address: account_component,
+        substate_id: account_component,
         version: null,
       },
       {
-        address: resource_address,
+        substate_id: resource_address,
         version: null,
       },
     ],
   };
   if (dest_account_exists) {
     submit_params.required_substates.push({
-      address: dest_account_component,
+      substate_id: dest_account_component,
       version: null,
     });
   }
@@ -262,7 +262,7 @@ async function getFreeTestCoins(
   const required_substates = [] as any[];
   if (accountExists) {
     required_substates.push({
-      address: account_component,
+      substate_id: account_component,
       version: null,
     });
   }

--- a/packages/snap/src/index.ts
+++ b/packages/snap/src/index.ts
@@ -108,7 +108,7 @@ async function getAccountData(
         return { type: 'nonfungible', resource_address, token_ids };
       }
 
-      thrdow new Error(
+      throw new Error(
         `Unknown resource container type ${JSON.stringify(container)}`,
       );
     }),
@@ -252,6 +252,7 @@ async function getFreeTestCoins(
     BigInt(amount),
     BigInt(fee),
   );
+ 
   const account_component =
     tari_wallet_lib.get_account_component_address(public_key);
 

--- a/packages/snap/src/index.ts
+++ b/packages/snap/src/index.ts
@@ -13,6 +13,7 @@ import {
 } from './tari_indexer_client';
 import { getRistrettoKeyPair } from './keys';
 import {
+  GetConfidentialVaultBalancesRequest,
   GetFreeTestCoinsRequest,
   GetRistrettoPublicKeyRequest,
   GetSubstateRequest,
@@ -313,6 +314,18 @@ async function getRistrettoPublicKey(
   };
 }
 
+async function getConfidentialVaultBalances(
+  req: JsonRpcRequest<Json[] | Record<string, Json>>,
+) {
+  const params = req.params as GetConfidentialVaultBalancesRequest;
+  const vault_substate = await getSubstate(params.vault_id);
+  const vault = vault_substate.substate.substate.Vault;
+  const keypair = await getRistrettoKeyPair(params.view_key_id);
+  const balances = tari_wallet_lib.view_vault_balance(vault, params.minimum_expected_value, params.maximum_expected_value, keypair.secret_key);
+
+  return balances;
+}
+
 /**
  * Handle incoming JSON-RPC requests, sent through `wallet_invokeSnap`.
  *
@@ -357,6 +370,8 @@ export const onRpcRequest: OnRpcRequestHandler = async ({
       return getTemplateDefinition(request);
     case 'getPublicKey':
       return getRistrettoPublicKey(request);
+    case 'getConfidentialVaultBalances':
+      return getConfidentialVaultBalances(request);
     default:
       throw new Error(`Method '${request.method}' not found.`);
   }

--- a/packages/snap/src/nfts.ts
+++ b/packages/snap/src/nfts.ts
@@ -48,10 +48,10 @@ export async function mintAccountNft(
 
   // include the input substates of the transaction (account and nft component)
   let required_substates = [
-    { address: account_component_address, version: null },
+    { substate_id: account_component_address, version: null },
   ];
   if (account_nft_exists) {
-    required_substates.push({ address: nft_component_address, version: null });
+    required_substates.push({ substate_id: nft_component_address, version: null });
   }
 
   // build and send the mint transaction
@@ -122,12 +122,12 @@ export async function transferNft(
 
   // include the input substates of the transaction
   let required_substates = [
-    { address: account_component_address, version: null },
-    { address: nft_address, version: null },
+    { substate_id: account_component_address, version: null },
+    { substate_id: nft_address, version: null },
   ];
   if (destination_account_exists) {
     required_substates.push({
-      address: destination_account_address,
+      substate_id: destination_account_address,
       version: null,
     });
   }
@@ -137,6 +137,7 @@ export async function transferNft(
     nft_resource,
   );
   const encoded_nft_id = await tari_wallet_lib.encode_non_fungible_id(nft_id);
+  const encoded_fee = await tari_wallet_lib.encode_amount(fee);
 
   // build and send the mint transaction
   // TODO: the instruction type should accept strings as well
@@ -167,7 +168,7 @@ export async function transferNft(
         CallMethod: {
           component_address: account_component_address,
           method: 'pay_fee',
-          args: [`Amount(${fee})`],
+          args: [{ Literal: encoded_fee }],
         },
       },
     ],

--- a/packages/snap/src/tari_indexer_client.ts
+++ b/packages/snap/src/tari_indexer_client.ts
@@ -51,11 +51,15 @@ export async function getSubstate(substate_address: string) {
 }
 
 export async function substateExists(substate_address: string) {
-  const result = await getSubstate(substate_address);
+  try {
+    const result = await getSubstate(substate_address);
 
-  if (result && !result.error) {
-    return true;
+    if (result && !result.error) {
+      return true;
+    }
+
+    return false;
+  } catch (error) {
+    return false;
   }
-
-  return false;
 }

--- a/packages/snap/src/transactions.ts
+++ b/packages/snap/src/transactions.ts
@@ -108,13 +108,14 @@ export async function sendInstructionInternal(
   }
 
   // automatically add fee payment instruction at the end
-  const fee_instructions = {
+  const encoded_fee = await tari_wallet_lib.encode_amount(fee);
+  const fee_instructions = [{
     CallMethod: {
       component_address: dump_account,
       method: 'pay_fee',
-      args: [`Amount(${fee})`],
+      args: [{ Literal: encoded_fee }],
     },
-  } as any;
+  }];
 
   const sendTransactionRequest: SendTransactionRequest = {
     instructions,

--- a/packages/snap/src/transactions.ts
+++ b/packages/snap/src/transactions.ts
@@ -5,6 +5,25 @@ import { sendIndexerRequest } from './tari_indexer_client';
 import { getRistrettoKeyPair } from './keys';
 import { SendInstructionRequest, SendTransactionRequest } from './types';
 
+const POLLING_INTERVAL_MILLIS = 500;
+const DEFAULT_WAIT_TIMEOUT_MILLIS = 10000;
+
+export async function waitForTransactionResult(transaction_id: string, timeout_millis = DEFAULT_WAIT_TIMEOUT_MILLIS ) {
+  let startTime = new Date().getTime();
+
+  while (new Date().getTime() < startTime + timeout_millis) {
+    await new Promise(resolve => setTimeout(resolve, POLLING_INTERVAL_MILLIS));
+    const response = await await sendIndexerRequest('get_transaction_result', {
+      transaction_id,
+    });
+    if(response.result && response.result.Finalized) {
+      return response.result.Finalized;
+    }
+  }
+
+  throw new Error(`Timeout waiting for transaction "${transaction_id}"`);
+}
+
 export async function sendTransactionInternal(
   _wasm: tari_wallet_lib.InitOutput,
   request: SendTransactionRequest,

--- a/packages/snap/src/types.ts
+++ b/packages/snap/src/types.ts
@@ -35,3 +35,10 @@ export type GetSubstateRequest = {
 export type GetRistrettoPublicKeyRequest = {
   index: number;
 };
+
+export type GetConfidentialVaultBalancesRequest = {
+  view_key_id: number;
+  vault_id: string;
+  minimum_expected_value: number | null;
+  maximum_expected_value: number | null;
+};

--- a/tari_wallet_lib/src/component.rs
+++ b/tari_wallet_lib/src/component.rs
@@ -1,19 +1,12 @@
 use tari_crypto::ristretto::RistrettoPublicKey;
 use tari_crypto::tari_utilities::hex::Hex;
 use tari_engine_types::component::new_account_address_from_parts;
-use tari_template_builtin::{ACCOUNT_NFT_TEMPLATE_ADDRESS, ACCOUNT_TEMPLATE_ADDRESS};
+use tari_template_builtin::ACCOUNT_TEMPLATE_ADDRESS;
 use tari_template_lib::prelude::ComponentAddress;
 use wasm_bindgen::JsError;
-
 
 pub fn get_account_address_from_public_key(public_key: &str) -> Result<ComponentAddress, JsError> {
     let destination_component_id = RistrettoPublicKey::from_hex(public_key).unwrap();
     let account_address = new_account_address_from_parts(&ACCOUNT_TEMPLATE_ADDRESS, &destination_component_id);
     Ok(account_address)
-}
-
-pub fn get_account_nft_address_from_public_key(public_key: &str) -> Result<ComponentAddress, JsError> {
-    let public_key = RistrettoPublicKey::from_hex(public_key).unwrap();
-    let account_nft_address = new_account_address_from_parts(&ACCOUNT_NFT_TEMPLATE_ADDRESS, &public_key);
-    Ok(account_nft_address)
 }

--- a/tari_wallet_lib/src/component.rs
+++ b/tari_wallet_lib/src/component.rs
@@ -2,7 +2,7 @@ use tari_crypto::ristretto::RistrettoPublicKey;
 use tari_crypto::tari_utilities::hex::Hex;
 use tari_engine_types::component::new_account_address_from_parts;
 use tari_template_builtin::{ACCOUNT_NFT_TEMPLATE_ADDRESS, ACCOUNT_TEMPLATE_ADDRESS};
-use tari_template_lib::{prelude::ComponentAddress, };
+use tari_template_lib::prelude::ComponentAddress;
 use wasm_bindgen::JsError;
 
 

--- a/tari_wallet_lib/src/crypto.rs
+++ b/tari_wallet_lib/src/crypto.rs
@@ -1,0 +1,13 @@
+use std::convert::Infallible;
+
+use tari_engine_types::confidential::ValueLookupTable;
+
+pub struct AlwaysMissLookupTable;
+
+impl ValueLookupTable for AlwaysMissLookupTable {
+    type Error = Infallible;
+
+    fn lookup(&mut self, _value: u64) -> Result<Option<[u8; 32]>, Self::Error> {
+        Ok(None)
+    }
+}

--- a/tari_wallet_lib/src/lib.rs
+++ b/tari_wallet_lib/src/lib.rs
@@ -3,7 +3,7 @@ pub mod metadata;
 
 use std::str::FromStr;
 
-use component::{get_account_address_from_public_key, get_account_nft_address_from_public_key};
+use component::get_account_address_from_public_key;
 use tari_crypto::keys::{PublicKey, SecretKey};
 use tari_crypto::ristretto::{RistrettoPublicKey, RistrettoSecretKey};
 use tari_crypto::tari_utilities::hex::Hex;
@@ -40,12 +40,6 @@ pub fn build_ristretto_public_key(ecdsa_str: &str) -> Result<String, JsError> {
 pub fn get_account_component_address(public_key: &str) -> Result<String, JsError> {
     let account_address = get_account_address_from_public_key(&public_key)?;
     Ok(account_address.to_string())
-}
-
-#[wasm_bindgen]
-pub fn get_account_nft_component_address(public_key: &str) -> Result<String, JsError> {
-    let account_nft_address = get_account_nft_address_from_public_key(&public_key)?;
-    Ok(account_nft_address.to_string())
 }
 
 #[wasm_bindgen]

--- a/tari_wallet_lib/src/lib.rs
+++ b/tari_wallet_lib/src/lib.rs
@@ -195,14 +195,9 @@ pub fn create_free_test_coins_transaction(
     ];
 
     if is_new_account {
-        let owner_token = NonFungibleAddress::from_public_key(
-            RistrettoPublicKeyBytes::from_bytes(account_public_key.as_bytes()).unwrap(),
-        );
-        let template_address: TemplateAddress = TemplateAddress::from_array([0; 32]);
-        instructions.push(Instruction::CallFunction {
-            template_address,
-            function: "create_with_bucket".to_string(),
-            args: args![owner_token, Workspace("free_test_coins")],
+        instructions.push(Instruction::CreateAccount {
+            owner_public_key: account_public_key.clone(),
+            workspace_bucket: Some("free_test_coins".to_string()),
         });
     } else {
         instructions.push(Instruction::CallMethod {

--- a/tari_wallet_lib/src/lib.rs
+++ b/tari_wallet_lib/src/lib.rs
@@ -80,6 +80,13 @@ pub fn encode_non_fungible_id(id_str: &str) -> Result<JsValue, JsError> {
 }
 
 #[wasm_bindgen]
+pub fn encode_amount(amount: i64) -> Result<JsValue, JsError> {
+    let amount = Amount::new(amount);
+    let encoded_amount = tari_bor::encode(&amount)?;
+    Ok(serde_wasm_bindgen::to_value(&encoded_amount)?)
+}
+
+#[wasm_bindgen]
 pub fn create_transaction(
     account_private_key_hex: &str,
     instructions_js: JsValue,


### PR DESCRIPTION
This PR brings back the snap up to the latest changes in the Tari network:
* VNs now expect the new `CreateAccount` instruction when creating an account. This affected the `Get Test Coins` functionality.
* `SubstateRequirement`'s `address` field renaming to `substate_id`. This affected all transactions made from the snap (e.g. transfers)
* Amount encoding in args must be `borsh` encoded. This also affected all transactions due to the `pay_fee` instruction at the end.
* Internal changes in the snap like `getSubstate` now throwing errors, which made some changes in the `substateExists` method necessary.
* Restored the  `Mint NFT` functionality, now the account NFT component needs to be created in a separated transaction and the address retrieved from the transaction result before minting
* Restored the display of NFT images and name in the gallery, as the metadata structure changed.
* Fixed the NFT transfers, there were some encoding issues with the NFT id

This PR also implements the `getConfidentialVaultBalances` that is used in ` tari.js` `provider` API. Up until now this was only available for the wallet daemon provider. To implement this functionality a new method `view_vault_balance` was implemented in the snap's Rust WASM library (`tari_template_lib`).