### PR TITLE
feat: add listSubstates method to snap

### DIFF
--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/tari-project/tari-snap.git"
   },
   "source": {
-    "shasum": "mx94alBup1U25qfQB9cKXZjPUM5KTneBYpLFo2dybeE=",
+    "shasum": "WwoCcjS25b2I8OlCSkt6Ixb/qas9G35N8L/Gvz9mOkM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/index.ts
+++ b/packages/snap/src/index.ts
@@ -18,6 +18,7 @@ import {
   GetFreeTestCoinsRequest,
   GetRistrettoPublicKeyRequest,
   GetSubstateRequest,
+  ListSubstatesRequest,
   TransferRequest,
 } from './types';
 import {
@@ -414,6 +415,15 @@ async function getSubstateHandler(
   return await getSubstate(substate_address);
 }
 
+async function listSubstates(
+  request: JsonRpcRequest<Json[] | Record<string, Json>>,
+) {
+  const params = request.params as ListSubstatesRequest;
+  return await sendIndexerRequest('list_substates', {
+    ...params,
+  });
+}
+
 async function getTemplateDefinition(
   request: JsonRpcRequest<Json[] | Record<string, Json>>,
 ) {
@@ -494,6 +504,8 @@ export const onRpcRequest: OnRpcRequestHandler = async ({
       return transferNft(wasm, request);
     case 'getSubstate':
       return getSubstateHandler(request);
+    case 'listSubstates':
+      return listSubstates(request);
     case 'getTemplateDefinition':
       return getTemplateDefinition(request);
     case 'getPublicKey':

--- a/packages/snap/src/types.ts
+++ b/packages/snap/src/types.ts
@@ -49,3 +49,10 @@ export type GetConfidentialVaultBalancesRequest = {
   minimum_expected_value: number | null;
   maximum_expected_value: number | null;
 };
+
+export type ListSubstatesRequest = {
+  filter_by_template: string | null;
+  filter_by_type: string | null;
+  limit: bigint | null;
+  offset: bigint | null;
+}


### PR DESCRIPTION
After https://github.com/tari-project/tari-dan/pull/1049 we now have a way to list substates via the indexer. This PR adds a new snap method `listSubstates` that proxies the call to the underlying indexer.